### PR TITLE
GUI: Turn off Redfish Event Log

### DIFF
--- a/meta-openpower/recipes-phosphor/webui/phosphor-webui/df-openpower/config.json
+++ b/meta-openpower/recipes-phosphor/webui/phosphor-webui/df-openpower/config.json
@@ -1,0 +1,3 @@
+{
+  "redfishEventLogDisabled" : true
+}

--- a/meta-openpower/recipes-phosphor/webui/phosphor-webui_%.bbappend
+++ b/meta-openpower/recipes-phosphor/webui/phosphor-webui_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI_append_df-openpower = " file://config.json"
+
+do_configure_append_df-openpower() {
+    # Overwrite the config.json to turn off/on Web UI panels
+    # E.g. Turn off the Redfish Event Log Panel since openpower systems use
+    # the D-Bus Event Log Panel
+    cp ${WORKDIR}/config.json ${S}/
+}


### PR DESCRIPTION
OpenPower systems use the exisiting D-Bus GUI panel, named "Event log".
This new Redfish Event Log panel was added here:
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-webui/+/15801
More detail there on why a 2nd event log page was added.

One day would like to share a Event Log panel in the GUI,
but at this time it is not possible due to the field differences.

OpenPower systems still use the following phosphor-logging features:
resolve field (not in the Redfish spec), delete event logs one at a
time (not yet implemented on the backend), and EventID (not in spec).

This is merged in master meta-ibm. 
This is the cherry-pick of the bump. 

See
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-webui/+/22868

(From meta-openpower rev: bc28b6abe52b70b60874fe57ee60ae12e196c359)

Tested: Built image with 22868.
        No longer see the Redfish Event Log panel.
Change-Id: Ie2d89fd059bfc3df4d333fac5c4177994425d462
Signed-off-by: Gunnar Mills <gmills@us.ibm.com>
Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>