### PR TITLE
Revert "Revert "Accelerator interface for sensorinventory items""

### DIFF
--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-host/merge_yamls.py
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-host/merge_yamls.py
@@ -12,6 +12,11 @@ import sys
 import yaml
 import copy
 
+# Custom representer for None types. This is to handle empty dictionaries.
+# By default Pyyaml outputs these as "null", whereas we want an empty character.
+def represent_none(self, _):
+    return self.represent_scalar('tag:yaml.org,2002:null', '')
+
 def dict_merge(target, source):
     """Deep merge for dicts.
 
@@ -42,6 +47,8 @@ if len(sys.argv) < 2:
 if len(sys.argv) == 2:
     # No overrides to handle
     sys.exit(0)
+
+yaml.add_representer(type(None), represent_none)
 
 target_filename = sys.argv[1]
 with open(target_filename) as target_file:

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-sensor-inventory-mrw-config/config.yaml
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-sensor-inventory-mrw-config/config.yaml
@@ -207,6 +207,7 @@ gpu_func_sensor:
             type: "bool"
             assert: true
             deassert: false
+    xyz.openbmc_project.Inventory.Item.Accelerator:
 # Field replaceable doesn't come as a sensor data
 # but we know that GPU is Field replaceable so setting
 # true in both cases.


### PR DESCRIPTION
This reverts commit 7fb0c049d3a290c8f9d7f7c9690cdef9a97b3c52.

Restore function reverted by
7fb0c049d3a290c8f9d7f7c9690cdef9a97b3c52, swift build issue
has now been resolved.

(From meta-phosphor rev: 7106ecfbc78b7ab9aba84dfa3319455cdc833903)

Merged into master here: https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/23520
Fixes https://github.com/ibm-openbmc/dev/issues/280 

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>
Change-Id: Iec14a8efc79f9094e6c37e0b1489e4e9ab9406c9
Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>