### PR TITLE
Add Accelerator Interface to GPU Sensors

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/configuration/acx22-yaml-config/acx22-ipmi-sensors-mrw.yaml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/configuration/acx22-yaml-config/acx22-ipmi-sensors-mrw.yaml
@@ -150,6 +150,7 @@ fw_boot_sensor:
     serviceInterface: org.freedesktop.DBus.Properties
 gpu_func_sensor:
     interfaces:
+        xyz.openbmc_project.Inventory.Item.Accelerator:
         xyz.openbmc_project.Inventory.Decorator.Replaceable:
             FieldReplaceable:
                 Offsets:


### PR DESCRIPTION
This commit adds the xyz.openbmc_project.Inventory.Item.Accelerator
interface to IPMI GPU functional sensors.

This was something done earlier by commit
f510f7b6b708b22db1f08faf369994f01edd0ddc.
The same is being ported now to the new sensor config YAML.

Tested:
Loaded this change up on a witherspoon. Verified that the
inventory objects created by host-ipmid now implement the
xyz.openbmc_project.Inventory.Item.Accelerator interface.

busctl call xyz.openbmc_project.ObjectMapper /xyz/openbmc_project/object_mapper
xyz.openbmc_project.ObjectMapper GetSubTree sias
"/xyz/openbmc_project/inventory" 0 1
"xyz.openbmc_project.Inventory.Item.Accelerator"
a{sa{sas}} 6
"/xyz/openbmc_project/inventory/system/chassis/motherboard/gv100card0"
....
....

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>
Change-Id: I1bba8d2d8957110a096b717d7f05b2f2e3568fe3