### PR TITLE
Nmi

### DIFF
--- a/designs/nmi_dbus_interface.md
+++ b/designs/nmi_dbus_interface.md
@@ -1,0 +1,92 @@
+# Design proposal for issuing NMI on servers that use OpenBMC
+
+Author: Lakshminarayana Kammath
+
+Primary assignee: Lakshminarayana Kammath
+
+Other contributors: Jayanth Othayoth
+
+Created: 2019-05-21
+
+
+## Problem Description
+Currently, servers that use OpenBMC cannot have the ability to capture relevant
+debug data when the host is unresponsive or hung. These systems need the ability
+to diagnose the root cause of hang and perform recovery along with debugging
+data collected.
+
+
+## Background and References
+There is a situation at customer places/lab where the host goes unresponsive
+causing system hang(https://github.com/ibm-openbmc/dev/issues/457).
+This means there is no way to figure out what went wrong with the host in a hung
+state. One has to recover the system with no relevant debug data captured.
+
+Whenever the host is unresponsive/running, Admin needs to trigger an NMI event
+which, in turn, triggers an architecture-dependent procedure that fires an
+interrupt on all the available processors on the system.
+
+## Proposed Design for servers that use OpenBMC
+This proposal aims to trigger NMI, which in turn will invoke an
+architecture-specific procedure that enables data collection followed by recovery
+of the Host. This will enable Host/OS development teams to analyze and fix any
+issues where they see host hang and unresponsive system.
+
+### D-Bus
+Introducing new D-Bus interface in the control.host namespace
+(/openbmc/phosphor-dbus-interfaces/xyz/openbmc_project/Control/Host/
+NMI.interface.yaml)
+and implement the new D-Bus back-end for respective processor specific targets.
+
+### BMC Support
+Enable NMI D-Bus phosphor interface and support this via Redfish
+
+### Redfish Schema used
+* Reference: DSP2046 2018.3,
+* ComputerSystem 1.6.0 schema provides an action called #ComputerSystem.Reset,
+  This action is used to reset the system.
+  The ResetType parameter is used for indicating the type of reset needs to be
+  performed. In this case, we can use
+  An NMI type
+    * Nmi: Generate a Diagnostic Interrupt (usually an NMI on x86 systems)
+     to cease normal operations, perform diagnostic actions and typically
+     halt the system.
+
+## High-Level Flow
+1. Host/OS is hung or unresponsive or one need to take kernel dump
+   to debug some error conditions.
+2. Admin/User can use the Redfish URI ComputerSystem.Reset that allows
+   POST operations and change the Action and ResetType properties to
+   {"Action":"ComputerSystem.Reset","ResetType":"Nmi"} to trigger NMI.
+3. Redfish URI will invoke a D-Bus NMI back-end call which will use an arch
+   specific back-end implementation of xyz.openbmc_project.Control.Host.NMI
+   to trigger an NMI on all the processors on the system.
+4. On receiving the NMI, the host will automatically invoke Architecture specific
+   actions. One such action could be; invoking the kdump followed by the reboot.
+
+* Note: NMI can be sent to the host in any state, not just at an unresponsive
+  state.
+
+## Alternatives Considered
+Extending  the existing  D-Bus interface state.Host namespace
+(/openbmc/phosphor-dbus-interfaces/xyz/openbmc_project/State/Host.interface.yaml)
+to support new RequestedHostTransition property called Nmi.
+D-Bus back-end can internally invoke processor-specific target to invoke NMI
+and do associated actions.
+
+There were strong reasons to move away from the above approach.
+phosphor-state-manager has always been focused on the states of the BMC,
+Chassis, and Host. NMI will be more of action against the host than
+a state.
+
+## Impacts
+This implementation only needs to make some changes to the system state when
+NMI is initiated irrespective of what host OS state is in, so it has minimal
+impact on the rest of the system.
+
+## Testing
+Depending on the platform hardware design, this test requires a host OS kernel
+module driver to create hard lockup/hang and then check the scenario is good.
+Also, one can invoke NMI to get the crash dump and confirm HOST received NMI
+via console logs.
+

--- a/meta-openpower/recipes-bsp/pdbg/pdbg_2.2.bb
+++ b/meta-openpower/recipes-bsp/pdbg/pdbg_2.2.bb
@@ -3,10 +3,10 @@ DESCRIPTION = "pdbg allows JTAG-like debugging of the host POWER processors"
 LICENSE     = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-PV = "2.1+git${SRCPV}"
+PV = "2.2+git${SRCPV}"
 
 SRC_URI += "git://github.com/open-power/pdbg.git"
-SRCREV = "2463be165d7eaa50b648c343e410d851edfb70ce"
+SRCREV = "dbbb35af951e36cb1ff134bdf74a5346d316e782"
 
 DEPENDS += "dtc-native"
 

--- a/meta-openpower/recipes-phosphor/host/op-proc-control_git.bb
+++ b/meta-openpower/recipes-phosphor/host/op-proc-control_git.bb
@@ -11,7 +11,7 @@ inherit autotools obmc-phosphor-utils pkgconfig pythonnative
 inherit systemd
 
 SRC_URI += "git://github.com/openbmc/openpower-proc-control"
-SRCREV = "b964c928156c2e71fe3bc9a2693b02cfbba5309c"
+SRCREV = "16ab00cb9383b17b8dd033a1cb300e2a013d55b1"
 
 DEPENDS += " \
         autoconf-archive-native \
@@ -19,9 +19,15 @@ DEPENDS += " \
         phosphor-dbus-interfaces \
         openpower-dbus-interfaces \
         "
+RDEPENDS_${PN} += "pdbg"
 
 TEMPLATE = "pcie-poweroff@.service"
 INSTANCE_FORMAT = "pcie-poweroff@{}.service"
 INSTANCES = "${@compose_list(d, 'INSTANCE_FORMAT', 'OBMC_CHASSIS_INSTANCES')}"
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "${TEMPLATE} ${INSTANCES}"
+
+SYSTEMD_SERVICE_${PN} +=  " \
+                         xyz.openbmc_project.Control.Host.NMI.service \
+                         nmi.service \
+                         "


### PR DESCRIPTION
Pull request has following check-in's

1) https://gerrit.openbmc-project.xyz/#/c/openbmc/docs/+/21772/
Design proposal for issuing NMI on servers that use OpenBMC

2) https://gerrit.openbmc-project.xyz/#/c/openbmc/openbmc/+/23943/
add a recipe for nmi service

           1) Generic interface to initiate non maskable interrupt
           on host processors.
           2) Bump up SRCREV for openpower-proc-control that enables NMI control

3) https://gerrit.openbmc-project.xyz/#/c/openbmc/openbmc/+/23924/
pdbg: Bump version to 2.2

       Upstream changes:
         - api for custom sbe chip-op
         - SBE chip-op based sreset
         - sbefifo procedure to get ffdc data

