### PR TITLE
Nmi openbmc

### DIFF
--- a/meta-openpower/recipes-bsp/pdbg/pdbg_2.2.bb
+++ b/meta-openpower/recipes-bsp/pdbg/pdbg_2.2.bb
@@ -3,10 +3,10 @@ DESCRIPTION = "pdbg allows JTAG-like debugging of the host POWER processors"
 LICENSE     = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-PV = "2.1+git${SRCPV}"
+PV = "2.2+git${SRCPV}"
 
 SRC_URI += "git://github.com/open-power/pdbg.git"
-SRCREV = "2463be165d7eaa50b648c343e410d851edfb70ce"
+SRCREV = "dbbb35af951e36cb1ff134bdf74a5346d316e782"
 
 DEPENDS += "dtc-native"
 

--- a/meta-openpower/recipes-phosphor/host/op-proc-control_git.bb
+++ b/meta-openpower/recipes-phosphor/host/op-proc-control_git.bb
@@ -11,7 +11,7 @@ inherit autotools obmc-phosphor-utils pkgconfig pythonnative
 inherit systemd
 
 SRC_URI += "git://github.com/openbmc/openpower-proc-control"
-SRCREV = "b964c928156c2e71fe3bc9a2693b02cfbba5309c"
+SRCREV = "16ab00cb9383b17b8dd033a1cb300e2a013d55b1"
 
 DEPENDS += " \
         autoconf-archive-native \
@@ -19,9 +19,15 @@ DEPENDS += " \
         phosphor-dbus-interfaces \
         openpower-dbus-interfaces \
         "
+RDEPENDS_${PN} += "pdbg"
 
 TEMPLATE = "pcie-poweroff@.service"
 INSTANCE_FORMAT = "pcie-poweroff@{}.service"
 INSTANCES = "${@compose_list(d, 'INSTANCE_FORMAT', 'OBMC_CHASSIS_INSTANCES')}"
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "${TEMPLATE} ${INSTANCES}"
+
+SYSTEMD_SERVICE_${PN} +=  " \
+                         xyz.openbmc_project.Control.Host.NMI.service \
+                         nmi.service \
+                         "

--- a/meta-openpower/recipes-phosphor/host/op-proc-control_git.bb
+++ b/meta-openpower/recipes-phosphor/host/op-proc-control_git.bb
@@ -2,6 +2,7 @@ SUMMARY = "OpenPower procedure control"
 DESCRIPTION = "Provides procedures that run against the host chipset"
 PR = "r1"
 PV = "1.0+git${SRCPV}"
+HOMEPAGE = "https://github.com/openbmc/openpower-proc-control"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
@@ -12,6 +13,9 @@ inherit systemd
 
 SRC_URI += "git://github.com/openbmc/openpower-proc-control"
 SRCREV = "16ab00cb9383b17b8dd033a1cb300e2a013d55b1"
+SRC_URI += "git://github.com/ibm-openbmc/openpower-proc-control;branch=OP940"
+SRCREV = "16ab00cb9383b17b8dd033a1cb300e2a013d55b1"
+
 
 DEPENDS += " \
         autoconf-archive-native \

--- a/meta-phosphor/recipes-phosphor/dbus/phosphor-dbus-interfaces_git.bb
+++ b/meta-phosphor/recipes-phosphor/dbus/phosphor-dbus-interfaces_git.bb
@@ -15,6 +15,8 @@ DEPENDS += "sdbus++-native"
 
 SRC_URI += "git://github.com/openbmc/phosphor-dbus-interfaces"
 SRCREV = "4ad9170e7549abbec3c8c52ac4b68a82e01f1c68"
+SRC_URI += "git://github.com/ibm-openbmc/phosphor-dbus-interfaces;branch=OP940"
+SRCREV = "a0c1ab165557ba70ae688d1e74d33c014852acb6"
 
 DEPENDS_remove_class-native = "sdbus++-native"
 DEPENDS_remove_class-nativesdk = "sdbus++-native"


### PR DESCRIPTION
https://gerrit.openbmc-project.xyz/#/c/openbmc/openbmc/+/23924/

pdbg: Bump version to 2.2

Upstream changes:
- api for custom sbe chip-op
- SBE chip-op based sreset
- sbefifo procedure to get ffdc data

(From meta-openpower rev: b91da78f6bbc02f6aee8a16b00ab9ef98c6b0d1d)

https://gerrit.openbmc-project.xyz/#/c/openbmc/openbmc/+/23943/

add a recipe for nmi service

1) Generic interface to initiate non maskable interrupt
   on host processors.
2) Bump up SRCREV for openpower-proc-control that enables NMI control

(From meta-openpower rev: e915010db7ab5a874908f91ddd7fd985efbc64c5)