### PR TITLE
meta-ibm: witherspoon: Power sensor associations

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/inventory/phosphor-inventory-manager/associations.json
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/inventory/phosphor-inventory-manager/associations.json
@@ -20,20 +20,6 @@
             {
                 "types":
                 {
-                    "rType": "chassis",
-                    "fType": "all_sensors"
-                },
-                "paths":
-                [
-                    "/xyz/openbmc_project/sensors/power/ps0_input_power",
-                    "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage",
-                    "/xyz/openbmc_project/sensors/current/ps0_output_current",
-                    "/xyz/openbmc_project/sensors/voltage/ps0_output_voltage"
-                ]
-            },
-            {
-                "types":
-                {
                     "rType": "inventory",
                     "fType": "leds"
                 },
@@ -53,20 +39,6 @@
                 {
                     "rType": "inventory",
                     "fType": "sensors"
-                },
-                "paths":
-                [
-                    "/xyz/openbmc_project/sensors/power/ps1_input_power",
-                    "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage",
-                    "/xyz/openbmc_project/sensors/current/ps1_output_current",
-                    "/xyz/openbmc_project/sensors/voltage/ps1_output_voltage"
-                ]
-            },
-            {
-                "types":
-                {
-                    "rType": "chassis",
-                    "fType": "all_sensors"
                 },
                 "paths":
                 [
@@ -1581,6 +1553,15 @@
                     "/xyz/openbmc_project/sensors/voltage/p1_vddr_voltage",
                     "/xyz/openbmc_project/sensors/voltage/p1_vdn_voltage",
 
+                    "/xyz/openbmc_project/sensors/power/p0_vdd_power",
+                    "/xyz/openbmc_project/sensors/power/p0_vcs_power",
+                    "/xyz/openbmc_project/sensors/power/p0_vddr_power",
+                    "/xyz/openbmc_project/sensors/power/p0_vdn_power",
+                    "/xyz/openbmc_project/sensors/power/p1_vdd_power",
+                    "/xyz/openbmc_project/sensors/power/p1_vcs_power",
+                    "/xyz/openbmc_project/sensors/power/p1_vddr_power",
+                    "/xyz/openbmc_project/sensors/power/p1_vdn_power",
+
                     "/xyz/openbmc_project/sensors/temperature/p0_vcs_temp",
                     "/xyz/openbmc_project/sensors/temperature/p0_vddr_temp",
                     "/xyz/openbmc_project/sensors/temperature/p0_vdd_temp",
@@ -1599,7 +1580,26 @@
                     "/xyz/openbmc_project/sensors/current/p1_vdd_current",
                     "/xyz/openbmc_project/sensors/current/p1_vdn_current",
 
-                    "/xyz/openbmc_project/sensors/power/total_power"
+                    "/xyz/openbmc_project/sensors/power/fan_disk_power",
+                    "/xyz/openbmc_project/sensors/power/io_power",
+                    "/xyz/openbmc_project/sensors/power/total_power",
+                    "/xyz/openbmc_project/sensors/power/p0_io_power",
+                    "/xyz/openbmc_project/sensors/power/p0_mem_power",
+                    "/xyz/openbmc_project/sensors/power/p0_power",
+                    "/xyz/openbmc_project/sensors/power/p1_io_power",
+                    "/xyz/openbmc_project/sensors/power/p1_mem_power",
+                    "/xyz/openbmc_project/sensors/power/p1_power",
+
+                    "/xyz/openbmc_project/sensors/voltage/ps0_input_voltage",
+                    "/xyz/openbmc_project/sensors/voltage/ps0_output_voltage",
+                    "/xyz/openbmc_project/sensors/voltage/ps1_input_voltage",
+                    "/xyz/openbmc_project/sensors/voltage/ps1_output_voltage",
+
+                    "/xyz/openbmc_project/sensors/power/ps0_input_power",
+                    "/xyz/openbmc_project/sensors/power/ps1_input_power",
+
+                    "/xyz/openbmc_project/sensors/current/ps0_output_current",
+                    "/xyz/openbmc_project/sensors/current/ps1_output_current"
                 ]
             }
         ]


### PR DESCRIPTION
Code review:
* https://gerrit.openbmc-project.xyz/c/openbmc/meta-ibm/+/23979
* Have 3 +1s.

Commit message:
BMCWeb uses ObjectMapper associations to find sensor information for
Redfish.  Due to BMCWeb enhancements for the Power and SensorCollection
schemas, the following Witherspoon association changes are required:

* Remove the "chassis" <-> "all_sensors" association for power supplies.
  Power supplies were considered chassis by BMCWeb as a short-term
  solution, but they have been moved to the Power schema.

* Add the power supply sensors to the "chassis" <-> "all_sensors"
  association for the top level chassis.

* Add other missing power sensors to the "chassis" <->
  "all_sensors" association for the top level chassis.  These
  associations were temporarily removed due to limitations in the BMCWeb
  support for power sensors.  These limitations have been addressed.

See https://github.com/openbmc/docs/blob/master/sensor-architecture.md
for more information on sensor associations used by BMCWeb.

Change-Id: I2d4a7cbe5242f1728e2acaecf971943f76660565
Signed-off-by: Shawn McCarney <shawnmm@us.ibm.com>