### PR TITLE
Remove skipOn for CPU core sensor

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/configuration/acx22-yaml-config/acx22-ipmi-sensors-mrw.yaml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/configuration/acx22-yaml-config/acx22-ipmi-sensors-mrw.yaml
@@ -43,7 +43,6 @@ cpucore_func_sensor:
                     7:
                         assert: true
                         deassert: false
-                        skipOn: deassert
                         type: bool
         xyz.openbmc_project.State.Decorator.OperationalStatus:
             Functional:


### PR DESCRIPTION
The CPU cores are currently skipped from inventory update if they
are not present. Suppose the CPU has 20 cores which are present and
the inventory is updated correctly. The inventory would persist this
information. If the CPU is replaced with 16 cores, the inventory would
still show 20 cores since the presence for the 4 cores which are absent
is not updated in the inventory.

This patch ensures that the presence for the cores are updated correctly,
including the ones that are absent. This would differ from the existing
behaviour that inventory objects are created for cores that are not present.

Change-Id: I744210833c10bf8be43ca06d2922844b38fcd6c6
Signed-off-by: Tom Joseph <tomjoseph@in.ibm.com>