### PR TITLE
Create WS specific channel_config.json

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/phosphor-ipmi-config/ibm-ac-server/channel_config.json
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/phosphor-ipmi-config/ibm-ac-server/channel_config.json
@@ -1,0 +1,178 @@
+{
+  "0" : {
+    "name" : "IPMB",
+    "is_valid" : true,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "ipmb",
+      "protocol_type" : "ipmb-1.0",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "1" : {
+    "name" : "eth0",
+    "is_valid" : true,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "lan-802.3",
+      "protocol_type" : "ipmb-1.0",
+      "session_supported" : "multi-session",
+      "is_ipmi" : true
+    }
+  },
+  "2" : {
+    "name" : "RESERVED",
+    "is_valid" : false,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "reserved",
+      "protocol_type" : "na",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "3" : {
+    "name" : "RESERVED",
+    "is_valid" : false,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "reserved",
+      "protocol_type" : "na",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "4" : {
+    "name" : "RESERVED",
+    "is_valid" : false,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "reserved",
+      "protocol_type" : "na",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "5" : {
+    "name" : "RESERVED",
+    "is_valid" : false,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "reserved",
+      "protocol_type" : "na",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "6" : {
+    "name" : "RESERVED",
+    "is_valid" : false,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "reserved",
+      "protocol_type" : "na",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "7" : {
+    "name" : "RESERVED",
+    "is_valid" : false,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "reserved",
+      "protocol_type" : "na",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "8" : {
+    "name" : "INTRABMC",
+    "is_valid" : true,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "oem",
+      "protocol_type" : "oem",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "9" : {
+    "name" : "RESERVED",
+    "is_valid" : false,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "reserved",
+      "protocol_type" : "na",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "10" : {
+    "name" : "RESERVED",
+    "is_valid" : false,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "reserved",
+      "protocol_type" : "na",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "11" : {
+    "name" : "RESERVED",
+    "is_valid" : false,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "reserved",
+      "protocol_type" : "na",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "12" : {
+    "name" : "RESERVED",
+    "is_valid" : false,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "reserved",
+      "protocol_type" : "na",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "13" : {
+    "name" : "RESERVED",
+    "is_valid" : false,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "reserved",
+      "protocol_type" : "na",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "14" : {
+    "name" : "SELF",
+    "is_valid" : false,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "ipmb",
+      "protocol_type" : "ipmb-1.0",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  },
+  "15" : {
+    "name" : "SMS",
+    "is_valid" : true,
+    "active_sessions" : 0,
+    "channel_info" : {
+      "medium_type" : "system-interface",
+      "protocol_type" : "kcs",
+      "session_supported" : "session-less",
+      "is_ipmi" : true
+    }
+  }
+}


### PR DESCRIPTION
Witherspoon has only one LAN interface which is channel number 1.
The json file provided by the phosphor layer has channel information
for two LAN interfaces. The phosphor layer config file is modified to
mark the channel number 2 as reserved.

Change-Id: I282bd09e84988a67e352fa4d156f1806e4a95824
Signed-off-by: Tom Joseph <tomjoseph@in.ibm.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
