### PR TITLE
Mihawk use negative-errno-on-fail config

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/sensors/phosphor-hwmon_%.bbappend
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/sensors/phosphor-hwmon_%.bbappend
@@ -1,5 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
+EXTRA_OECONF_append_mihawk = " --enable-negative-errno-on-fail"
+
 SRC_URI_append_ibm-ac-server = " \
            file://70-hwmon.rules \
            file://70-max31785-hwmon.rules \


### PR DESCRIPTION
Enable this config for mihawk so the fan sensors are working, otherwise
hwmon will fail and exit when fans are not working.

Tested: Verify that the fan_tach sensors return -ETIMEOUT when host is
        powered off and do not exit with failure.

Signed-off-by: Ben Pai <Ben_Pai@wistron.com>
Change-Id: I5b808183afcdb193ea39d7cd91e978a7902a4d34

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
