### PR TITLE
Enable mac2 on mihawk platform

### DIFF
--- a/meta-ibm/meta-witherspoon/conf/machine/mihawk.conf
+++ b/meta-ibm/meta-witherspoon/conf/machine/mihawk.conf
@@ -12,6 +12,7 @@ require conf/machine/include/ast2500.inc
 require conf/machine/include/obmc-bsp-common.inc
 require conf/machine/include/openpower.inc
 require conf/machine/include/p9.inc
+require conf/distro/include/phosphor-aspeednic-use-mac2.inc
 
 PHOSPHOR_MRW_LICENSE = "Apache-2.0"
 PHOSPHOR_MRW_LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"

--- a/meta-phosphor/aspeed-layer/recipes-bsp/u-boot/files/0002-board-aspeed-aspeednic-Use-MAC2-for-networking.patch
+++ b/meta-phosphor/aspeed-layer/recipes-bsp/u-boot/files/0002-board-aspeed-aspeednic-Use-MAC2-for-networking.patch
@@ -1,0 +1,43 @@
+From cbb09e400a5283e5b543e2b01b8c0038890a5260 Mon Sep 17 00:00:00 2001
+From: Xo Wang <xow@google.com>
+Date: Thu, 20 Oct 2016 17:42:13 -0700
+Subject: [PATCH 2/2] board/aspeed, aspeednic: Use MAC2 for networking
+
+Enable and select MAC2 for aspeednic.
+
+Signed-off-by: Xo Wang <xow@google.com>
+---
+ drivers/net/aspeednic.c       | 4 ++--
+ include/configs/ast-g5-ncsi.h | 1 +
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/aspeednic.c b/drivers/net/aspeednic.c
+index 8b85893..cff8370 100644
+--- a/drivers/net/aspeednic.c
++++ b/drivers/net/aspeednic.c
+@@ -18,8 +18,8 @@
+ /* From the board config file */
+ #define CONFIG_MAC1_PHY_SETTING         2
+ #define CONFIG_MAC2_PHY_SETTING         0
+-#define CONFIG_ASPEED_MAC_NUMBER  1
+-#define CONFIG_ASPEED_MAC_CONFIG  1 // config MAC1
++#define CONFIG_ASPEED_MAC_NUMBER  2
++#define CONFIG_ASPEED_MAC_CONFIG  2 // config MAC2
+ #define _PHY_SETTING_CONCAT(mac) CONFIG_MAC##mac##_PHY_SETTING
+ #define _GET_MAC_PHY_SETTING(mac) _PHY_SETTING_CONCAT(mac)
+ #define CONFIG_ASPEED_MAC_PHY_SETTING \
+diff --git a/include/configs/ast-g5-ncsi.h b/include/configs/ast-g5-ncsi.h
+index f73a8f1..1408618 100644
+--- a/include/configs/ast-g5-ncsi.h
++++ b/include/configs/ast-g5-ncsi.h
+@@ -22,6 +22,7 @@
+ /* Ethernet */
+ #define CONFIG_LIB_RAND
+ #define CONFIG_ASPEEDNIC
++#define CONFIG_MAC2_ENABLE
+ 
+ /* platform.S settings */
+ #define	CONFIG_DRAM_ECC_SIZE		0x10000000
+-- 
+2.8.0.rc3.226.g39d4020
+

--- a/meta-phosphor/aspeed-layer/recipes-bsp/u-boot/u-boot-aspeed.inc
+++ b/meta-phosphor/aspeed-layer/recipes-bsp/u-boot/u-boot-aspeed.inc
@@ -12,6 +12,9 @@ SRC_URI_append_aspeed_df-obmc-ubi-fs = " \
 SRC_URI_append_aspeed_df-isolate-bmc = " \
     file://0001-aspeed-Disable-unnecessary-features.patch \
     "
+SRC_URI_append_aspeed_df-aspeednic-use-mac2 = " \
+    file://0002-board-aspeed-aspeednic-Use-MAC2-for-networking.patch \
+    "
 
 do_patch[depends] += "os-release:do_populate_sysroot"
 

--- a/meta-phosphor/conf/distro/include/phosphor-aspeednic-use-mac2.inc
+++ b/meta-phosphor/conf/distro/include/phosphor-aspeednic-use-mac2.inc
@@ -1,0 +1,2 @@
+DISTRO_FEATURES += "obmc-aspeednic-use-mac2"
+DISTROOVERRIDES .= ":df-aspeednic-use-mac2"


### PR DESCRIPTION
1. u-boot-aspeed: Add distro feature for mac2 support
2. meta-ibm: Enable mac2 on mihawk platform