### PR TITLE
Avahi:Fix to check and create avahi group and user before starting avahi

### DIFF
--- a/recipes-connectivity/avahi/avahi-daemon/avahi-daemon-override.conf
+++ b/recipes-connectivity/avahi/avahi-daemon/avahi-daemon-override.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStartPre=/bin/sh -c "grep -q avahi: /etc/group || /usr/sbin/addgroup --system avahi
+grep -q avahi: /etc/passwd || /usr/sbin/adduser --system --no-create-home --ingroup avahi avahi"

--- a/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/recipes-connectivity/avahi/avahi_%.bbappend
@@ -1,0 +1,11 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/avahi-daemon:"
+
+SRC_URI += "file://avahi-daemon-override.conf"
+
+FILES_avahi-daemon_append += "${systemd_system_unitdir}/avahi-daemon.service.d/avahi-daemon-override.conf"
+
+do_install_append() {
+
+        install -Dm 0755 ${WORKDIR}/avahi-daemon-override.conf \
+        ${D}${systemd_system_unitdir}/avahi-daemon.service.d/avahi-daemon-override.conf
+}


### PR DESCRIPTION
service.

Avahi service fails to start when we code update from image which has no
avahi service to image which has avahi service,As part of code update.
we don't touch the persistent file(/etc/group or /etc/password).
Now the image which is going to be updated needs these persistent files
to be updated.

I have tried to add avahi user using extrausers and pkg_postinst scripts
I could see updated /etc/group and /etc/password files with avahi entry
in rootfs build directory, but after code update to this new BMC image
we dont see these udpated files on the system, where as this new image
requires avahi user and the group to be present in the /etc/passwd and
/etc/group on the system.

Implemented service override file to check and create avahi group
and user before starting avahi service.

Tested By:
1.Code updating images
2.Reboot

Signed-off-by: Ravi Teja <raviteja28031990@gmail.com>
Change-Id: I797333404dad515a1bd8c22833ff73c3316e3216

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
