### PR TITLE
Value setting for IPMI clear security keys

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/configuration/acx22-yaml-config/acx22-ipmi-sensors-mrw.yaml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/configuration/acx22-yaml-config/acx22-ipmi-sensors-mrw.yaml
@@ -336,3 +336,24 @@ vrm_vdd_temp_sensor:
     sensorNamePattern: nameLeaf
     serviceInterface: org.freedesktop.DBus.Properties
     unit: xyz.openbmc_project.Sensor.Value.Unit.DegreesC
+clear_host_security_keys:
+    bExp: 0
+    entityID: 0xD0
+    entityInstance: 1
+    interfaces:
+        org.open_power.Control.TPM.SecurityKeys:
+            ClearHostSecurityKeys:
+                Offsets:
+                    255:
+                        type: uint8_t
+    multiplierM: 1
+    offsetB: 0
+    path: /org/open_power/control/host0/ClearHostSecurityKeys
+    rExp: 0
+    readingType: readingData
+    mutability: Mutability::Write|Mutability::Read
+    sensorNamePattern: nameLeaf
+    scale: 0
+    sensorReadingType: 1
+    sensorType: 0xCD
+    serviceInterface: org.freedesktop.DBus.Properties

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/settings/phosphor-settings-manager/ClearHostSecurityKeys-default-zero.override.yml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/settings/phosphor-settings-manager/ClearHostSecurityKeys-default-zero.override.yml
@@ -1,0 +1,6 @@
+---
+/org/open_power/control/host0/ClearHostSecurityKeys:
+    - Interface: org.open_power.Control.TPM.SecurityKeys
+      Properties:
+          ClearHostSecurityKeys:
+             Default: 0

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
@@ -1,3 +1,11 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 SRC_URI_append_ibm-ac-server = " file://TPMEnable-default-true.override.yml"
+SRC_URI_append_ibm-ac-server += " file://ClearHostSecurityKeys-default-zero.override.yml"
 SRC_URI_append_mihawk = " file://TPMEnable-default-true.override.yml"
+# Provide a means to enable/disable openpower dbus linking
+DEPENDS += "openpower-dbus-interfaces openpower-dbus-interfaces-native"
+PACKAGECONFIG ??= "link-op-dbus-intfs"
+PACKAGECONFIG[link-op-dbus-intfs] = " \
+        --enable-link-op-dbus-intfs, \
+        --disable-link-op-dbus-intfs, ,\
+        "


### PR DESCRIPTION
Support to set the value for ClearSecurityKeys property which can be used to
indicate when certain security keys need to be cleared or reset those values
back to its default state from the system by the host. This property is mapped
to an IPMI sensor and default value will be zero. Setting this property does
not gurantee a successful operation as additional conditions like the physical
presence pin or jumper settings will be checked by the host to clear/reset the
sensitive data.

Tested: Verified that the property is getting created with the expected
default value as zero and can be updated to different values using ipmitool
or busctl command.

1. Default value output:
busctl get-property xyz.openbmc_project.Settings
/org/open_power/control/host0/ClearHostSecurityKeys
org.open_power.Control.TPM.SecurityKeys ClearHostSecurityKeys
y 0

ipmitool -I lanplus -H 9.3.185.33 -U root -P 0penBmc raw 0x04 0x2D 0xE8
00 40 00 00

2. Set to a new value as 5 using busctl command:
busctl set-property xyz.openbmc_project.Settings
/org/open_power/control/host0/ClearHostSecurityKeys
org.open_power.Control.TPM.SecurityKeys ClearHostSecurityKeys y 5

3. After setting to a new value as 5:
ipmitool -I lanplus -H 9.3.185.33 -U root -P 0penBmc raw 0x04 0x2D 0xE8
05 40 00 00

4. ipmitool command to set the value as 9
ipmitool -I lanplus -H 9.3.185.33 -U root -P 0penBmc raw 0x04 0x30 0xE8
0x00 0x04 0x00 0x00 0x00 0x00 0x00 0x00 0x00

ipmitool -I lanplus -H 9.3.185.33 -U root -P 0penBmc raw 0x04 0x2D 0xE8
09 40 00 00

5. Invalid value test o/p:
ipmitool -I lanplus -H 9.3.185.33 -U root -P 0penBmc raw 0x04 0x30 0xE8
0x00 0x12C 0x00 0x00 0x00 0x00 0x00 0x00 0x00
Given data "0x12C" is invalid.

Signed-off-by: Jayashankar Padath <jayashankar.padath@in.ibm.com>
Change-Id: I6f3aa57d96cdeb90a77c74008575b07017423e87

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
