### PR TITLE
SW470068: Add support for enabling/disabling network IPMI

### DIFF
--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-host_git.bb
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-host_git.bb
@@ -50,6 +50,7 @@ RDEPENDS_${PN} += "virtual/obmc-watchdog"
 RDEPENDS_${PN} += "${VIRTUAL-RUNTIME_obmc-bmc-state-manager}"
 RDEPENDS_${PN} += "${VIRTUAL-RUNTIME_obmc-bmc-version}"
 RDEPENDS_${PN} += "${VIRTUAL-RUNTIME_obmc-bmc-updater}"
+RDEPENDS_${PN} += "iptables"
 
 inherit useradd
 

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-net/ipmi-net-firewall.sh
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-net/ipmi-net-firewall.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+if [ -f $IPTABLESRULE ]; then
+    iptables-restore < $IPTABLESRULE
+fi

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-net_git.bb
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-net_git.bb
@@ -16,9 +16,15 @@ DEPENDS += "systemd"
 DEPENDS += "phosphor-ipmi-host"
 
 SRC_URI += "git://github.com/openbmc/phosphor-net-ipmid"
+SRC_URI += "file://ipmi-net-firewall.sh"
 SRCREV = "f8a34fc47183c553b9e78301e6f55170dbb7976d"
 
 S = "${WORKDIR}/git"
+
+do_install_append() {
+            install -m 0755 ${WORKDIR}/ipmi-net-firewall.sh \
+            ${D}${bindir}/ipmi-net-firewall.sh
+}
 
 FILES_${PN} += " \
         ${systemd_system_unitdir}/${PN}@.service \


### PR DESCRIPTION
Added dependency for iptables to enable/disable IPMI and added the script
to apply the iptables when the network IPMI starts.

Change-Id: Ie7aa55530f8e0ca789bd05b1c53d1c57f46766ee
Signed-off-by: Tom Joseph <tomjoseph@in.ibm.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
