### PR TITLE
meta-phosphor: obmc-ikvm: SRCREV bump 23135dd9

### DIFF
--- a/meta-phosphor/recipes-graphics/obmc-ikvm/obmc-ikvm_git.bb
+++ b/meta-phosphor/recipes-graphics/obmc-ikvm/obmc-ikvm_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=75859989545e37968a99b631ef42722e"
 DEPENDS = " libvncserver systemd sdbusplus phosphor-logging phosphor-dbus-interfaces"
 
 SRC_URI = "git://github.com/openbmc/obmc-ikvm"
-SRCREV = "133bfa2d5b1b3af0b8e819b4cd210a0e1ac0445c"
+SRCREV = "23135dd97ec828e2abeacce06d472bb45bc358d5"
 
 PV = "1.0+git${SRCPV}"
 


### PR DESCRIPTION
Include the fix for SW471168, which is merged in master.