### PR TITLE
avahi: Ensure user and group added

### DIFF
--- a/meta-phosphor/recipes-connectivity/avahi/avahi-daemon/avahi-daemon-override.conf
+++ b/meta-phosphor/recipes-connectivity/avahi/avahi-daemon/avahi-daemon-override.conf
@@ -1,3 +1,3 @@
 [Service]
-ExecStartPre=/bin/sh -c "grep -q avahi: /etc/group || /usr/sbin/addgroup --system avahi
-grep -q avahi: /etc/passwd || /usr/sbin/adduser --system --no-create-home --ingroup avahi avahi"
+ExecStartPre=/bin/sh -c "grep -q avahi: /etc/group || /usr/sbin/addgroup --system avahi"
+ExecStartPre=/bin/sh -c "grep -q avahi: /etc/passwd || /usr/sbin/adduser --system --no-create-home --ingroup avahi avahi"

--- a/meta-phosphor/recipes-connectivity/avahi/avahi_%.bbappend
+++ b/meta-phosphor/recipes-connectivity/avahi/avahi_%.bbappend
@@ -6,6 +6,6 @@ FILES_avahi-daemon_append += "${systemd_system_unitdir}/avahi-daemon.service.d/a
 
 do_install_append() {
 
-        install -Dm 0755 ${WORKDIR}/avahi-daemon-override.conf \
+        install -Dm 0644 ${WORKDIR}/avahi-daemon-override.conf \
         ${D}${systemd_system_unitdir}/avahi-daemon.service.d/avahi-daemon-override.conf
 }


### PR DESCRIPTION
This is a patch on top of a change already in OP940 that was incorrect
due to a misplaced line feed. This commit updates the code to what is
now in gerrit at:
https://gerrit.openbmc-project.xyz/c/openbmc/meta-phosphor/+/24271

The extra line feed was added to the bbappend due to git requiring some
sort of change to detect the file permission change. git only detects
non-exe to/from exe. This permission change was required to avoid a
warning by systemd.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
