### PR TITLE
mihawk-xml: srcrev bump b9929ba9fd..f6ec5aa0f9

### DIFF
--- a/meta-ibm/meta-witherspoon/conf/machine/mihawk.conf
+++ b/meta-ibm/meta-witherspoon/conf/machine/mihawk.conf
@@ -18,7 +18,7 @@ require conf/distro/include/phosphor-aspeednic-use-mac2.inc
 PHOSPHOR_MRW_LICENSE = "Apache-2.0"
 PHOSPHOR_MRW_LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 PHOSPHOR_MRW_URI = "git://github.com/open-power/mihawk-xml"
-PHOSPHOR_MRW_REV = "b9929ba9fd96d78da01bce8a2a157851dce9e5cb"
+PHOSPHOR_MRW_REV = "f6ec5aa0f9803d44b147a7670dec7ec935f59582"
 
 
 


### PR DESCRIPTION
Change tpm connector instance name to prevent wrong name in bmc yaml
file.

(From meta-ibm rev: dad5e4f56d827cab311d9399a48bd09c26296f15)

Change-Id: I919a8faadd3036b98215b76195602c1f8fb12435
Signed-off-by: Ben Pai <Ben_Pai@wistron.com>
Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
