### PR TITLE
nginx: OP940 prepare for downgrade

### DIFF
--- a/meta-ibm/recipes-httpd/nginx/files/nginx-prep-downgrade.service
+++ b/meta-ibm/recipes-httpd/nginx/files/nginx-prep-downgrade.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Prepare file system for downgrade to nginx
+After=network.target
+
+[Service]
+Restart=no
+Type=oneshot
+RemainAfterExit=true
+SyslogIdentifier=nginx-prep-downgrade
+ExecStart=/bin/mkdir -p /etc/ssl/certs/nginx
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-ibm/recipes-httpd/nginx/nginx-prep-downgrade.bb
+++ b/meta-ibm/recipes-httpd/nginx/nginx-prep-downgrade.bb
@@ -1,0 +1,24 @@
+SUMMARY = "IBM nginx prepare for downgrade"
+DESCRIPTION = "Prepare file system for downgrade to nginx release"
+PR = "r1"
+HOMEPAGE = "http://github.com/openbmc/meta-ibm"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${IBMBASE}/COPYING.apache-2.0;md5=34400b68072d710fecd0a2940a0d1658"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+inherit systemd
+inherit obmc-phosphor-systemd
+
+# Add a service to create the directory needed to store nginx
+# certificates.  This is needed in case the BMC uses code update to go
+# to a firmware image that uses nginx.  The directory must be created
+# in the overlay filesystem (not in the generated file system) to
+# survive the downgrade.  The service is "harmless" and only creates
+# one additional subdirectory.
+
+# This service can be removed in the first release that does not
+# support a downgrade path to an OpenBMC 2.6 or earlier release.
+
+SERVICE = "nginx-prep-downgrade.service"
+SYSTEMD_SERVICE_${PN} += " ${SERVICE}"

--- a/meta-ibm/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
+++ b/meta-ibm/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
@@ -1,1 +1,2 @@
 RDEPENDS_${PN}-logging += "ibm-logging"
+RDEPENDS_${PN}-software += "nginx-prep-downgrade"


### PR DESCRIPTION
This adds a service which creates a directory needed in case the BMC is
downgraded to a release which used nginx.
The directory must be created in the overlay filesystem (not in the
generated file system) so it will survive the downgrade.  The service
is "harmless" and only creates one additional subdirectory.

This is needed for OpenBMC 2.7 and later systems (which use BMCWeb) and
may be code updated (downgraded) to OpenBMC 2.6 and earlier releases (which
use nginx).

Without this fix, the BMC fails to start its nginx server and does not
provide HTTP, REST, or Web services.  The underlying cause of the server
failing to start is: the directory it needs to write files into does not
is not present.
The problem does not affect the SSH service.  Commands like "systemctl
status nginx" show messages about "unable to write 'random state'".
The problem can be worked around by creating the /etc/ssl/certs/nginx/
directory, then starting the service: systemctl start nginx

This service can be removed in the first release that does not support a
downgrade path to an OpenBMC 2.6 or earlier release.

Tested on an OpenBMC 2.7 image:
  rm -r /etc/ssl/certs/nginx/   # cleanup workarounds
  code update to image which has this fix
  systemctl --no-pager list-units nginx-prep-downgrade.service
  systemctl status nginx-prep-downgrade.service
  ls /etc/ssl/certs/nginx
  The service successfully creates the directory.

Fixes: https://github.com/openbmc/openbmc/issues/3564

Signed-off-by: Joseph Reynolds <jrey@linux.ibm.com>
Change-Id: I32c3231fd877f5f5ea523d584d34892610b6cd0c

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
