### PR TITLE
dropbear: OP940 disable-weak-ciphers backport

### DIFF
--- a/poky/meta/recipes-core/dropbear/dropbear.inc
+++ b/poky/meta/recipes-core/dropbear/dropbear.inc
@@ -19,7 +19,8 @@ SRC_URI = "http://matt.ucc.asn.au/dropbear/releases/dropbear-${PV}.tar.bz2 \
            file://dropbear@.service \
            file://dropbear.socket \
            file://dropbear.default \
-           ${@bb.utils.contains('DISTRO_FEATURES', 'pam', '${PAM_SRC_URI}', '', d)} "
+           ${@bb.utils.contains('DISTRO_FEATURES', 'pam', '${PAM_SRC_URI}', '', d)} \
+           ${@bb.utils.contains('PACKAGECONFIG', 'disable-weak-ciphers', 'file://dropbear-disable-weak-ciphers.patch', '', d)} "
 
 PAM_SRC_URI = "file://0005-dropbear-enable-pam.patch \
                file://0006-dropbear-configuration-file.patch \
@@ -45,8 +46,9 @@ SBINCOMMANDS = "dropbear dropbearkey dropbearconvert"
 BINCOMMANDS = "dbclient ssh scp"
 EXTRA_OEMAKE = 'MULTI=1 SCPPROGRESS=1 PROGRAMS="${SBINCOMMANDS} ${BINCOMMANDS}"'
 
-PACKAGECONFIG ?= ""
+PACKAGECONFIG ?= "disable-weak-ciphers"
 PACKAGECONFIG[system-libtom] = "--disable-bundled-libtom,--enable-bundled-libtom,libtommath libtomcrypt"
+PACKAGECONFIG[disable-weak-ciphers] = ""
 
 EXTRA_OECONF += "\
  ${@bb.utils.contains('DISTRO_FEATURES', 'pam', '--enable-pam', '--disable-pam', d)}"

--- a/poky/meta/recipes-core/dropbear/dropbear/dropbear-disable-weak-ciphers.patch
+++ b/poky/meta/recipes-core/dropbear/dropbear/dropbear-disable-weak-ciphers.patch
@@ -1,0 +1,44 @@
+This feature disables all CBC, SHA1, and diffie-hellman group1 ciphers 
+in the dropbear ssh server and client since they're considered weak ciphers
+and we want to support the stong algorithms.
+
+Upstream-Status: Inappropriate [configuration]
+Signed-off-by: Joseph Reynolds <joseph.reynolds1@ibm.com>
+
+Index: dropbear-2019.78/default_options.h
+===================================================================
+--- dropbear-2019.78.orig/default_options.h
++++ dropbear-2019.78/default_options.h
+@@ -91,7 +91,7 @@ IMPORTANT: Some options will require "ma
+ 
+ /* Enable CBC mode for ciphers. This has security issues though
+  * is the most compatible with older SSH implementations */
+-#define DROPBEAR_ENABLE_CBC_MODE 1
++#define DROPBEAR_ENABLE_CBC_MODE 0
+ 
+ /* Enable "Counter Mode" for ciphers. This is more secure than
+  * CBC mode against certain attacks. It is recommended for security
+@@ -101,7 +101,7 @@ IMPORTANT: Some options will require "ma
+ /* Message integrity. sha2-256 is recommended as a default, 
+    sha1 for compatibility */
+ #define DROPBEAR_SHA1_HMAC 1
+-#define DROPBEAR_SHA1_96_HMAC 1
++#define DROPBEAR_SHA1_96_HMAC 0
+ #define DROPBEAR_SHA2_256_HMAC 1
+ 
+ /* Hostkey/public key algorithms - at least one required, these are used
+@@ -149,12 +149,12 @@ IMPORTANT: Some options will require "ma
+  * Small systems should generally include either curve25519 or ecdh for performance.
+  * curve25519 is less widely supported but is faster
+  */ 
+-#define DROPBEAR_DH_GROUP14_SHA1 1
++#define DROPBEAR_DH_GROUP14_SHA1 0
+ #define DROPBEAR_DH_GROUP14_SHA256 1
+ #define DROPBEAR_DH_GROUP16 0
+ #define DROPBEAR_CURVE25519 1
+ #define DROPBEAR_ECDH 1
+-#define DROPBEAR_DH_GROUP1 1
++#define DROPBEAR_DH_GROUP1 0
+ 
+ /* When group1 is enabled it will only be allowed by Dropbear client
+ not as a server, due to concerns over its strength. Set to 0 to allow


### PR DESCRIPTION
This is a backport of the poky dropbear disable-weak-ciphers patch which
is in master and will not be accepted into poky/warrior.  This backports
the patch in openbmc/poky/warrior.

The openembedded-core recipe with this patch is here:
https://layers.openembedded.org/layerindex/recipe/4674/

This is needed to avoid regressing the OpenBMC 2.7 SSH security
configuration.  This fix also removes additional weak ciphers as
previously agreed in gerrit code reviews.

The recipe adds a new PACKAGECONFIG disable-weak-ciphers, on by default,
which patches dropbear SSH ciphers.

Tested: Yes

Signed-off-by: Joseph Reynolds <joseph.reynolds1@ibm.com>
Change-Id: I39194acfd405edf7beb4a01e2731cee751bc7bec

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
