### PR TITLE
SW477941:WA: Manually add groups and permission

### DIFF
--- a/meta-phosphor/recipes-phosphor/users/phosphor-user-manager/add_groups_workaround.sh
+++ b/meta-phosphor/recipes-phosphor/users/phosphor-user-manager/add_groups_workaround.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+# Create groups if not available
+for i in web ipmi redfish priv-admin priv-operator priv-user priv-callback; do
+    if grep -q $i /etc/group; then
+        echo "$i already exists"
+    else
+        echo "$i does not exist, add it"
+        groupadd -f $i
+    fi
+done
+
+# Root needs to be a member of these groups
+for i in ipmi web redfish priv-admin; do
+    if id -nG root | grep -q $i; then
+        echo "root already in $i"
+    else
+        echo "root not in group $i, add it"
+        usermod -a -G $i root
+    fi
+done

--- a/meta-phosphor/recipes-phosphor/users/phosphor-user-manager/xyz.openbmc_project.User.Manager.service
+++ b/meta-phosphor/recipes-phosphor/users/phosphor-user-manager/xyz.openbmc_project.User.Manager.service
@@ -1,7 +1,13 @@
 [Unit]
 Description=Phosphor User Manager
+Wants=obmc-mapper.target
+After=obmc-mapper.target
+After=sysinit.target
+ConditionPathIsReadWrite=/etc
 
 [Service]
+# Ensure appropriate groups and permissions set
+ExecStartPre=/usr/bin/env add_groups_workaround.sh
 ExecStart=/usr/bin/env phosphor-user-manager
 SyslogIdentifier=phosphor-user-manager
 Restart=always

--- a/meta-phosphor/recipes-phosphor/users/phosphor-user-manager_git.bb
+++ b/meta-phosphor/recipes-phosphor/users/phosphor-user-manager_git.bb
@@ -38,6 +38,12 @@ DBUS_SERVICE_phosphor-ldap = " \
         xyz.openbmc_project.Ldap.Config.service \
         xyz.openbmc_project.LDAP.PrivilegeMapper.service \
 "
+SRC_URI += "file://add_groups_workaround.sh"
 SRC_URI += "git://github.com/ibm-openbmc/phosphor-user-manager;branch=OP940"
 SRCREV = "c10f815d8d29e702afbbbbbf6ae1807d1566274b"
 S = "${WORKDIR}/git"
+
+do_install_append() {
+        install -d ${D}${bindir}
+        install -m 0755 ${WORKDIR}/add_groups_workaround.sh ${D}${bindir}/add_groups_workaround.sh
+}


### PR DESCRIPTION
There was a change to add these new groups and permissions to
the code base but since this information is stored in /etc/group,
it is not automatically updated since that file has been written
to and a copy is out in /var/persist/etc/group. If you factory
reset your system then you will get the correct settings but can
not require a factory reset to existing users.

This commit just ensures the new groups are created and root is
in the appropriate groups before starting the user management
service.

Change-Id: I1b35de76daa5d35c85b58983321c2ffd34b33c79
Signed-off-by: Andrew Geissler <geissonator@yahoo.com>

Conflicts:
	meta-phosphor/recipes-phosphor/users/phosphor-user-manager.bb
