### PR TITLE
add_groups_workaround requires bash RDEPENDS

### DIFF
--- a/meta-phosphor/recipes-phosphor/users/phosphor-user-manager_git.bb
+++ b/meta-phosphor/recipes-phosphor/users/phosphor-user-manager_git.bb
@@ -16,6 +16,7 @@ DEPENDS += "phosphor-dbus-interfaces"
 DEPENDS += "boost"
 DEPENDS += "nss-pam-ldapd"
 DEPENDS += "systemd"
+RDEPENDS_${PN} += "bash"
 PACKAGE_BEFORE_PN = "phosphor-ldap"
 
 inherit useradd


### PR DESCRIPTION
This dependency was missed in the previous pull request and is required
now to handle the add_groups_workaround.sh script

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>