### PR TITLE
SW476410:ipkvm: bring SRCREVs to master

### DIFF
--- a/meta-openembedded/meta-oe/recipes-graphics/libvncserver/libvncserver_0.9.12.bb
+++ b/meta-openembedded/meta-oe/recipes-graphics/libvncserver/libvncserver_0.9.12.bb
@@ -31,7 +31,9 @@ FILES_libvncclient = "${libdir}/libvncclient.*"
 inherit cmake
 
 SRC_URI = "git://github.com/LibVNC/libvncserver"
-SRCREV = "c0a23857a5c42b45b6d22ccf7218becd1fa69402"
-
+SRCREV = "1354f7f1bb6962dab209eddb9d6aac1f03408110"
+PV .= "+git${SRCPV}"
 
 S = "${WORKDIR}/git"
+
+EXTRA_OECMAKE = "-DMAKE_INSTALL_LIBDIR=${libdir}"

--- a/meta-phosphor/recipes-graphics/obmc-ikvm/obmc-ikvm_git.bb
+++ b/meta-phosphor/recipes-graphics/obmc-ikvm/obmc-ikvm_git.bb
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=75859989545e37968a99b631ef42722e"
 
 DEPENDS = " libvncserver systemd sdbusplus phosphor-logging phosphor-dbus-interfaces"
 
-SRC_URI = "git://github.com/ibm-openbmc/obmc-ikvm;branch=OP940"
-SRCREV = "6260d0dc3af97bf0d9bfeeea103d98f5b94f147a"
+SRC_URI = "git://github.com/openbmc/obmc-ikvm"
+SRCREV = "7cf1f1d43ef9b4c312bfb2c7c61514ca93a53ee6"
 
 PV = "1.0+git${SRCPV}"
 


### PR DESCRIPTION
Bump both libvncserver and obmc-ikvm to master levels. The obmc-ikvm commit we
need, 85d0455227ea6bb60f5dc1cf6e67d6e27eed7788, depends on the latest
libvncserver.