### PR TITLE
preinit-mounts: Add check for overlay file errors

### DIFF
--- a/meta-phosphor/recipes-phosphor/preinit-mounts/preinit-mounts/init
+++ b/meta-phosphor/recipes-phosphor/preinit-mounts/preinit-mounts/init
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+mount_overlay() {
+  if ! mount overlay /etc -t overlay -o defaults,lowerdir=/etc,upperdir=/var/persist/etc,workdir=/var/persist/etc-work; then
+    mount overlay /etc -t overlay -o defaults,lowerdir=/etc:/var/persist/etc
+  fi
+}
+
 if ! mount ubi0:rwfs /var -t ubifs -o defaults; then
   if ! mount ubi0:rwfs /var -t ubifs -o defaults,ro; then
     mount tmpfs /var -t tmpfs -o defaults
@@ -12,8 +18,32 @@ rm -rf /var/persist/etc-work/*
 # rm -rf specifically skips . and .. directories; pipe all output to null to avoid the error message
 rm -rf /var/persist/etc-work/.* > /dev/null 2>&1
 
-if ! mount overlay /etc -t overlay -o defaults,lowerdir=/etc,upperdir=/var/persist/etc,workdir=/var/persist/etc-work; then
-  mount overlay /etc -t overlay -o defaults,lowerdir=/etc:/var/persist/etc
-fi
+mount_overlay
+
+# Check if there are any issues accessing the files in /etc after mounting the
+# overlay by doing an 'ls' command
+error="/var/overlay-error"
+cd /var/persist/etc/
+for i in *; do
+  # Only check regular files at the top of the directory
+  if [[ -f $i ]]; then
+    ls -i /etc/$i >/dev/null 2>${error};
+    if [[ -s ${error} ]]; then
+      # We don't have a way to print this error to the journal, delete it
+      rm -f ${error}
+      # Attempt to re-create the overlay by moving out the overlay contents and
+      # copying them back to /etc, which would create them back in the overlay
+      cd
+      umount /etc
+      rm -rf /var/persist/etc-save
+      mv /var/persist/etc /var/persist/etc-save
+      mkdir -p /var/persist/etc
+      mount_overlay
+      cp -rp /var/persist/etc-save/* /etc/
+      rm -rf /var/persist/etc-save
+      break
+    fi
+  fi
+done
 
 exec /lib/systemd/systemd


### PR DESCRIPTION
During a downgrade, errors from the overlay files have been seen.
Try to recreate the overlay when this happens by re-copying the
files into /etc.

Tested: Put this change in OP930, then on a system running OP940, performed
factory reset, then downgraded to the modified OP930 level and verified the
new code ran and the system booted. Without this change, this downgrade scenario fails.

Defect: https://w3.rchland.ibm.com/projects/bestquest/?defect=SW478084

Change-Id: Idde33213cb0a6bac0b4468e22b3b4fa424508267
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>
