### PR TITLE
SW479257: Revert the medium type to Other LAN

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/phosphor-ipmi-config/ibm-ac-server/channel_config.json
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/phosphor-ipmi-config/ibm-ac-server/channel_config.json
@@ -15,7 +15,7 @@
     "is_valid" : true,
     "active_sessions" : 0,
     "channel_info" : {
-      "medium_type" : "lan-802.3",
+      "medium_type" : "other-lan",
       "protocol_type" : "ipmb-1.0",
       "session_supported" : "multi-session",
       "is_ipmi" : true


### PR DESCRIPTION
On OP940 and latest master the IPMI channel information for LAN is
802.3 LAN. For backward compatibility of XCAT , it is reverted to
"other-lan".

Signed-off-by: Tom Joseph <tomjoseph@in.ibm.com>

Please do not submit a Pull Request via github.  Our project makes use of
Gerrit for patch submission and review.  For more details please
see https://github.com/openbmc/docs/blob/master/CONTRIBUTING.md#submitting-changes-via-gerrit-server
