### PR TITLE
meta-ibm: Add the ncsi-netlink service for mihawk

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/network/phosphor-network_%.bbappend
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/network/phosphor-network_%.bbappend
@@ -1,8 +1,15 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/network:"
 SRC_URI_append_ibm-ac-server = " file://ncsi-netlink.service"
+SRC_URI_append_mihawk = " file://ncsi-netlink.service"
+
 SYSTEMD_SERVICE_${PN}_append_ibm-ac-server = " ncsi-netlink.service"
+SYSTEMD_SERVICE_${PN}_append_mihawk = " ncsi-netlink.service"
 
 do_install_append_ibm-ac-server() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/ncsi-netlink.service ${D}${systemd_system_unitdir}
+}
+do_install_append_mihawk() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/ncsi-netlink.service ${D}${systemd_system_unitdir}
 }


### PR DESCRIPTION
Prevent the BMC from failing over to the other ethernet port if it
detects a network drop on the one it's using.

https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/26411

(From meta-ibm rev: 4c3ea265721c4a1152ae75711af68c6caa29a772)

Signed-off-by: Ben Pai <Ben_Pai@wistron.com>
Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>
Change-Id: Id7f3a939e967e661937098a2ea95fdb79e973862
Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>

