### PR TITLE
mihawk: phosphor-gpu SRCREV bump f57188be82..dc27898de5

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/gpu/phosphor-gpu_git.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/gpu/phosphor-gpu_git.bb
@@ -19,7 +19,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 SRC_URI := "git://github.com/wistron-corporation/phosphor-gpu.git;protocol=git"
-SRCREV := "f57188be82d3b4f42d912136e80be3dd55fbea7b"
+SRCREV := "dc27898de5cc99c411ef54039bfde9316f925fe3"
 S = "${WORKDIR}/git"
 
 DBUS_SERVICE_${PN} += "xyz.openbmc_project.gpu.manager.service"


### PR DESCRIPTION
Close idle channels to avoid device conflicts.

BMC will get the wrong GPU temp when connected to multiple GPUs. The 
reason is that the channel is not closed after reading the data.