### PR TITLE
Add udev rules for mihawk id_button.service

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/gpio/id-button.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/gpio/id-button.bb
@@ -9,22 +9,19 @@ DEPENDS += "virtual/obmc-gpio-monitor"
 RDEPENDS_${PN} += "virtual/obmc-gpio-monitor"
 
 S = "${WORKDIR}"
-SRC_URI += "file://toggle_identify_led.sh"
+SRC_URI += " \
+        file://toggle_identify_led.sh \
+        file://99-gpio-keys.rules \
+        "
 
 do_install() {
         install -d ${D}${bindir}
         install -m 0755 ${WORKDIR}/toggle_identify_led.sh \
             ${D}${bindir}/toggle_identify_led.sh
+        install -d ${D}${base_libdir}/udev/rules.d/
+        install ${WORKDIR}/99-gpio-keys.rules ${D}${base_libdir}/udev/rules.d/
 }
 
 SYSTEMD_ENVIRONMENT_FILE_${PN} +="obmc/gpio/id_button"
 
-ID_BUTTON_SERVICE = "id_button"
-
-TMPL = "phosphor-gpio-monitor@.service"
-INSTFMT = "phosphor-gpio-monitor@{0}.service"
-TGT = "multi-user.target"
-FMT = "../${TMPL}:${TGT}.requires/${INSTFMT}"
-
 SYSTEMD_SERVICE_${PN} += "id-button-pressed.service"
-SYSTEMD_LINK_${PN} += "${@compose_list(d, 'FMT', 'ID_BUTTON_SERVICE')}"

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/gpio/id-button/99-gpio-keys.rules
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/gpio/id-button/99-gpio-keys.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="input", ENV{ID_PATH}=="platform-gpio-keys", RUN+="/bin/systemctl start phosphor-gpio-monitor@id_button.service"


### PR DESCRIPTION
/dev/input/by-path/platform-gpio-keys-event is not created by udev
while id_button.service is running. In mihawk it takes much more
time for udev to create those files maybe there are more devices
in Mihawk. This patch adds the udev rules to activat the id_button
service. This patch is not quilified to upstream but should be
enough for mihawk OP940

The timing of kernle, udev and id_button service
Nov 01 09:31:11 mihawk kernel: input: gpio-keys as /devices/platform
/gpio-keys/input/input2

Nov 01 09:31:11 mihawk systemd[1]: Started udev Kernel Device Manager.

Nov 01 09:31:17 mihawk systemd[1]: Started udev Coldplug all Devices.

Nov 01 09:31:46 mihawk systemd[1]: phosphor-gpio-monitor@id_button.
service: Main process exited, code=killed, status=6/ABRT
Nov 01 09:31:46 mihawk systemd[1]: phosphor-gpio-monitor@id_button.
service: Failed with result 'signal'.

lrwxrwxrwx    1 root     root             9 Nov  1 09:32
/dev/input/by-path/platform-gpio-keys-event

Tested: The id_button servcie can be activated by this rules without
        error