### PR TITLE
meta-ibm: Modify mihawk themal policy

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/dbus/thermal-policy/mihawk/thermal-policy.yaml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/dbus/thermal-policy/mihawk/thermal-policy.yaml
@@ -1,8 +1,8 @@
 # Mihawk thermal policy for PDM.
 #
 # Shut down the system if more than three cores
-# have a temperature greater than 100 degrees Celcius.
-
+# have a temperature greater than 95 degrees Celcius.
+# or ambient temperature greater than 45 degrees Celcius.
 
 - name: core sensors
   description: >
@@ -107,9 +107,29 @@
     - meta: SENSOR
       path: /xyz/openbmc_project/sensors/temperature/p1_core23_temp
 
+- name: ambient sensor
+  description: >
+    'The machine has one ambient temperature sensors.'
+  class: group
+  group: path
+  members:
+    - meta: SENSOR
+      path: /xyz/openbmc_project/sensors/temperature/ambient_temp
+
 - name: core temp
   description: >
     'Monitor the temperature of each core.'
+  class: group
+  group: property
+  type: int64
+  members:
+    - interface: xyz.openbmc_project.Sensor.Value
+      meta: TEMP
+      property: Value
+
+- name: ambient temp
+  description: >
+    'Monitor the ambient temperature.'
   class: group
   group: property
   type: int64
@@ -127,6 +147,15 @@
   properties: core temp
   callback: check temps
 
+- name: watch ambient temp
+  description: >
+    'Trigger logic on ambient temp changes.'
+  class: watch
+  watch: property
+  paths: ambient sensor
+  properties: ambient temp
+  callback: check ambient temp
+
 - name: check temps
   description: >
     'If this condition passes at least three cores are running
@@ -139,7 +168,21 @@
   countop: '>='
   countbound: 3
   op: '>='
-  bound: 115000
+  bound: 95000
+  oneshot: true
+
+- name: check ambient temp
+  description: >
+    'If the ambient sensor is too hot. Shut the system down.'
+  class: condition
+  condition: count
+  paths: ambient sensor
+  properties: ambient temp
+  callback: ambient log and shutdown
+  countop: '>='
+  countbound: 1
+  op: '>='
+  bound: 45000
   oneshot: true
 
 - name: log and shutdown
@@ -151,6 +194,16 @@
     - shutdown
     - create criticalhigh error
     - create shutdown error
+
+- name: ambient log and shutdown
+  description: >
+    'Shut the system down and log an event.'
+  class: callback
+  callback: group
+  members:
+    - shutdown
+    - create ambient criticalhigh error
+    - create ambient shutdown error
 
 - name: shutdown
   description: >
@@ -177,6 +230,16 @@
   error: xyz::openbmc_project::Sensor::Threshold::Error::CriticalHigh
   metadata: xyz::openbmc_project::Sensor::Threshold::CriticalHigh::SENSOR_DATA
 
+- name: create ambient criticalhigh error
+  description: >
+    'Create a Ambient CriticalHigh Error log.'
+  class: callback
+  callback: elog_with_metadata
+  paths: ambient sensor
+  properties: ambient temp
+  error: xyz::openbmc_project::Sensor::Threshold::Error::CriticalHigh
+  metadata: xyz::openbmc_project::Sensor::Threshold::CriticalHigh::SENSOR_DATA
+
 - name: create shutdown error
   description: >
     'Create a SystemShutdown Error log.'
@@ -185,3 +248,12 @@
   paths: core sensors
   properties: core temp
   error: xyz::openbmc_project::State::Shutdown::ThermalEvent::Error::Processor
+
+- name: create ambient shutdown error
+  description: >
+    'Create a SystemShutdown Error log.'
+  class: callback
+  callback: elog
+  paths: ambient sensor
+  properties: ambient temp
+  error: xyz::openbmc_project::State::Shutdown::ThermalEvent::Error::Ambient


### PR DESCRIPTION
1. According to the thermal team test results, the cpu core should be
shutdown when it exceeds 95 degrees Celcius.
2.mihawk's ambient temperature exceeds 45 degrees Celcius should be
shutsown to avoid system damage.

Tested:
Cpu core exceeds 95 degrees Celcius or ambient exceeds 45 degrees
Celcius system will shutdown.

https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/27435
(From meta-ibm rev: 7f94a4b3a7c3d7346ae4b1bade6287ea1a70c41a)

Signed-off-by: Ben Pai <Ben_Pai@wistron.com>
Change-Id: I303a5047dc0b29e46829f4b838eaa6f151b13735
Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>