### PR TITLE
meta-ibm: Adjust the mihawk fan control event

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/fans/phosphor-fan-control-events-config/mihawk/events.yaml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/fans/phosphor-fan-control-events-config/mihawk/events.yaml
@@ -479,7 +479,7 @@ events:
                           value: 70000
                           type: int64_t
                       factor:
-                          value: 7000
+                          value: 4000
                           type: int64_t
                       delta:
                           value: 5
@@ -519,7 +519,7 @@ events:
                           value: 3
                           type: uint64_t
                 timer:
-                    interval: 5
+                    interval: 3
               - name: speed_changes_based_on_onboard_temps
                 groups:
                     - name: zone0_onboard
@@ -538,7 +538,7 @@ events:
                 actions:
                     - name: set_net_increase_speed
                       property:
-                          value: 50000
+                          value: 55000
                           type: int64_t
                       factor:
                           value: 1000
@@ -548,10 +548,10 @@ events:
                           type: uint64_t
                     - name: set_net_decrease_speed
                       property:
-                          value: 47000
+                          value: 52000
                           type: int64_t
                       factor:
-                          value: 3000
+                          value: 1000
                           type: int64_t
                       delta:
                           value: 3
@@ -614,7 +614,7 @@ events:
                 actions:
                     - name: set_net_increase_speed
                       property:
-                          value: 70
+                          value: 80
                           type: int64_t
                       factor:
                           value: 1
@@ -624,7 +624,7 @@ events:
                           type: uint64_t
                     - name: set_net_decrease_speed
                       property:
-                          value: 67
+                          value: 77
                           type: int64_t
                       factor:
                           value: 4

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/sensors/phosphor-hwmon/mihawk/obmc/hwmon/ahb/apb/bus@1e78a000/i2c-bus@400/emc1403@4c.conf
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/sensors/phosphor-hwmon/mihawk/obmc/hwmon/ahb/apb/bus@1e78a000/i2c-bus@400/emc1403@4c.conf
@@ -1,2 +1,5 @@
 LABEL_temp2 = "ambient_temp"
-
+WARNHI_temp2 = "38000"
+WARNLO_temp2 = "0"
+CRITHI_temp2 = "40000"
+CRITLO_temp2 = "0"


### PR DESCRIPTION
According to our thermal team test report, we need to adjust the fan
control event.

Tested
Fan speed will be based on new fan control events.

https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/27509
(From meta-ibm rev: f242630e5a8195eeef089f01537b9be4fde000a2)

Signed-off-by: Ben Pai <Ben_Pai@wistron.com>
Change-Id: Ib4c296f128d625e78387cead26c46c76faa39535
Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>