### PR TITLE
Fix pseq-pgood-monitor's interval for mihawk

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mihawk/pseq-monitor-pgood.service
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mihawk/pseq-monitor-pgood.service
@@ -9,5 +9,5 @@ ConditionPathExists=!/run/openbmc/chassis@0-on
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/env pseq-monitor -a mihawk-cpld-pgood-monitor -i 5000
+ExecStart=/usr/bin/env pseq-monitor -a mihawk-cpld-pgood-monitor -i 10000
 SyslogIdentifier=pseq-monitor


### PR DESCRIPTION
Because mihawk's pseq-pgood-monitor interval is too short, 
pseq-pgood-monitor runs early and reads power errors which 
don't exist, so the adjustment interval is 5s to 10s.

Tested:
Test system on the first IPL after flashing firmware.