### PR TITLE
meta-ibm: Add a mechanism to monitor ambient and occ

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/fans/phosphor-fan-control-events-config/mihawk/events.yaml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/fans/phosphor-fan-control-events-config/mihawk/events.yaml
@@ -299,6 +299,60 @@ actions:
           - altevents
 
 events:
+    - name: default_fan_floor_on_service_fail
+      groups:
+          - name: zone0_ambient
+            interface: xyz.openbmc_project.Sensor.Value
+            property:
+                name: Value
+                type: int64_t
+      matches:
+          - name: nameOwnerChanged
+      actions:
+          - name: call_actions_based_on_timer
+            timer:
+                delay: 5
+                type: oneshot
+            actions:
+                - name: default_floor_on_missing_owner
+    - name: high_speed_on_occ0_service_fail
+      groups:
+          - name: occ0_object
+            interface: org.open_power.OCC.Status
+            property:
+                name: OccActive
+                type: bool
+      matches:
+          - name: nameOwnerChanged
+      actions:
+          - name: call_actions_based_on_timer
+            timer:
+                delay: 5
+                type: oneshot
+            actions:
+                - name: set_speed_on_missing_owner
+                  speed:
+                      value: 255
+                      type: uint64_t
+    - name: high_speed_on_occ1_service_fail
+      groups:
+          - name: occ1_object
+            interface: org.open_power.OCC.Status
+            property:
+                name: OccActive
+                type: bool
+      matches:
+          - name: nameOwnerChanged
+      actions:
+          - name: call_actions_based_on_timer
+            timer:
+                delay: 5
+                type: oneshot
+            actions:
+                - name: set_speed_on_missing_owner
+                  speed:
+                      value: 255
+                      type: uint64_t
     - name: missing_before_high_speed_air
       groups:
           - name: air_cooled_zone0_fans


### PR DESCRIPTION
Fan speed can be increased when occ or ambient is abnormal, so add the
monitor of the ambient and OCC control services.

Signed-off-by: Ben Pai <Ben_Pai@wistron.com>

https://gerrit.openbmc-project.xyz/c/openbmc/meta-ibm/+/27624