### PR TITLE
Op940.01 - lock out the root user

### DIFF
--- a/meta-phosphor/recipes-extended/pam/libpam/pam.d/common-auth
+++ b/meta-phosphor/recipes-extended/pam/libpam/pam.d/common-auth
@@ -8,7 +8,7 @@
 # traditional Unix authentication mechanisms.
 
 # here are the per-package modules (the "Primary" block)
-auth	[success=ok user_unknown=ignore default=2]	pam_tally2.so deny=5 unlock_time=300
+auth	[success=ok user_unknown=ignore default=2]	pam_tally2.so deny=5 unlock_time=300 even_deny_root
 # Try for local user first, and then try for ldap
 auth	[success=2 default=ignore]	pam_unix.so quiet
 -auth    [success=1 default=ignore]  	pam_ldap.so ignore_unknown_user ignore_authinfo_unavail


### PR DESCRIPTION
A previous commit added support to lockout a user for 5 minutes after 5 failed authentication attempts.  However, that did not include the root user.  This commit includes the root user in the account lockout scheme.

The upstream review is here: https://gerrit.openbmc-project.xyz/c/openbmc/meta-phosphor/+/27527