### PR TITLE
PAM: also_deny_root

### DIFF
--- a/meta-phosphor/recipes-extended/pam/libpam/pam.d/common-auth
+++ b/meta-phosphor/recipes-extended/pam/libpam/pam.d/common-auth
@@ -8,7 +8,7 @@
 # traditional Unix authentication mechanisms.
 
 # here are the per-package modules (the "Primary" block)
-auth	[success=ok user_unknown=ignore default=2]	pam_tally2.so deny=5 unlock_time=300
+auth	[success=ok user_unknown=ignore default=2]	pam_tally2.so deny=5 unlock_time=300 also_deny_root root_unlock_time=300
 # Try for local user first, and then try for ldap
 auth	[success=2 default=ignore]	pam_unix.so quiet
 -auth    [success=1 default=ignore]  	pam_ldap.so ignore_unknown_user ignore_authinfo_unavail


### PR DESCRIPTION
This extends the account lockout to the root user.
See https://github.com/ibm-openbmc/openbmc/commit/5841aed74e48f701407e4885a8ee6c8b07846641

Note that as configured here, the Redfish AccountService REST APIs to PATCH the
AccountLockoutThreshold and AccountLockoutDuration properties do not apply to
the root user.  Changing the values will have no effect on the lockout policy
for root.  That is the intention.

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>