### PR TITLE
Update phosphor-gpu version and add monitor gpu service

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/fans/phosphor-fan-control-events-config/mihawk/events.yaml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/fans/phosphor-fan-control-events-config/mihawk/events.yaml
@@ -146,6 +146,11 @@ groups:
           - /temperature/gpu5
           - /temperature/gpu6
           - /temperature/gpu7
+    - name: service_gpu
+      description: Group of monitor gpu service
+      type: /xyz/openbmc_project/sensors
+      members:
+          - /temperature/gpu0
 matches:
     - name: propertiesChanged
       description: >
@@ -302,6 +307,22 @@ events:
     - name: default_fan_floor_on_service_fail
       groups:
           - name: zone0_ambient
+            interface: xyz.openbmc_project.Sensor.Value
+            property:
+                name: Value
+                type: int64_t
+      matches:
+          - name: nameOwnerChanged
+      actions:
+          - name: call_actions_based_on_timer
+            timer:
+                delay: 5
+                type: oneshot
+            actions:
+                - name: default_floor_on_missing_owner
+    - name: default_fan_floor_on_gpu_service_fail
+      groups:
+          - name: service_gpu
             interface: xyz.openbmc_project.Sensor.Value
             property:
                 name: Value

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/gpu/phosphor-gpu_git.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/gpu/phosphor-gpu_git.bb
@@ -19,7 +19,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 SRC_URI := "git://github.com/wistron-corporation/phosphor-gpu.git;protocol=git"
-SRCREV := "dc27898de5cc99c411ef54039bfde9316f925fe3"
+SRCREV := "f634dc0677de4a4776f832c68685345634004820"
 S = "${WORKDIR}/git"
 
 DBUS_SERVICE_${PN} += "xyz.openbmc_project.gpu.manager.service"


### PR DESCRIPTION
1. Update phosphor-gpu version
2. Add a monitor gpu service. When the gpu service fails, the fan can
   ensure that there is enough fan speed.

Because the phosphor-gpu currently only uses the branch in op940, it 
directly pulls the request.