### PR TITLE
Fix patch error & remove psu-sync function & add pseq-monitor for mihawk to OP940

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-kernel/linux/linux-aspeed/0001-wistron-wps.patch
+++ b/meta-ibm/meta-witherspoon/recipes-kernel/linux/linux-aspeed/0001-wistron-wps.patch
@@ -1,14 +1,14 @@
-From 80515160b982989b254e7ea7d82f072babfa3108 Mon Sep 17 00:00:00 2001
+From 5762c92bdc6f0b0860c7dee5fe4ce605fb7f749c Mon Sep 17 00:00:00 2001
 From: Ben Pai <Ben_Pai@wistron.com>
-Date: Fri, 13 Dec 2019 17:46:44 +0800
+Date: Mon, 16 Dec 2019 18:28:43 +0800
 Subject: [PATCH] wistron-wps
 
 ---
  arch/arm/boot/dts/aspeed-bmc-opp-mihawk.dts |   4 +-
  drivers/hwmon/pmbus/Kconfig                 |   9 ++
  drivers/hwmon/pmbus/Makefile                |   1 +
- drivers/hwmon/pmbus/wistron-wps.c           | 173 ++++++++++++++++++++++++++++
- 4 files changed, 185 insertions(+), 2 deletions(-)
+ drivers/hwmon/pmbus/wistron-wps.c           | 174 ++++++++++++++++++++++++++++
+ 4 files changed, 186 insertions(+), 2 deletions(-)
  create mode 100644 drivers/hwmon/pmbus/wistron-wps.c
 
 diff --git a/arch/arm/boot/dts/aspeed-bmc-opp-mihawk.dts b/arch/arm/boot/dts/aspeed-bmc-opp-mihawk.dts
@@ -31,13 +31,14 @@ index 52e88b0..ad4853c 100644
  	};
  
 diff --git a/drivers/hwmon/pmbus/Kconfig b/drivers/hwmon/pmbus/Kconfig
-index b658848..ecf0900 100644
+index b658848..56a8489 100644
 --- a/drivers/hwmon/pmbus/Kconfig
 +++ b/drivers/hwmon/pmbus/Kconfig
-@@ -210,6 +210,15 @@ config SENSORS_UCD9200
+@@ -209,6 +209,15 @@ config SENSORS_UCD9200
+ 
  	  This driver can also be built as a module. If so, the module will
  	  be called ucd9200.
- 
++  
 +config SENSORS_WISTRON_WPS
 +	tristate "Wistron Power Supply"
 +	help
@@ -46,10 +47,9 @@ index b658848..ecf0900 100644
 +
 +	  This driver can also be built as a module. If so, the module will
 +	  be called wistron-wps.
-+
+ 
  config SENSORS_ZL6100
  	tristate "Intersil ZL6100 and compatibles"
- 	help
 diff --git a/drivers/hwmon/pmbus/Makefile b/drivers/hwmon/pmbus/Makefile
 index c950ea9..072afcb 100644
 --- a/drivers/hwmon/pmbus/Makefile
@@ -62,10 +62,10 @@ index c950ea9..072afcb 100644
  obj-$(CONFIG_SENSORS_ZL6100)	+= zl6100.o
 diff --git a/drivers/hwmon/pmbus/wistron-wps.c b/drivers/hwmon/pmbus/wistron-wps.c
 new file mode 100644
-index 0000000..850f1bb
+index 0000000..aa33567
 --- /dev/null
 +++ b/drivers/hwmon/pmbus/wistron-wps.c
-@@ -0,0 +1,173 @@
+@@ -0,0 +1,174 @@
 +// SPDX-License-Identifier: GPL-2.0-or-later
 +/*
 + * Copyright 2019 Wistron Corp.
@@ -110,7 +110,7 @@ index 0000000..850f1bb
 +	int *idxp = file->private_data;
 +	int idx = *idxp;
 +	struct wistron_wps *psu = to_psu(idxp, idx);
-+	char data[I2C_SMBUS_BLOCK_MAX+2] = { 0 };
++	char data[I2C_SMBUS_BLOCK_MAX + 2] = { 0 };
 +
 +	switch (idx) {
 +	case WPS_DEBUGFS_FRU:
@@ -138,6 +138,7 @@ index 0000000..850f1bb
 +
 +done:
 +	data[rc] = '\n';
++	rc += 2;
 +
 +	return simple_read_from_buffer(buf, count, ppos, data, rc);
 +}

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
@@ -2,6 +2,6 @@ RDEPENDS_${PN}-inventory_append_ibm-ac-server = " openpower-fru-vpd openpower-oc
 RDEPENDS_${PN}-inventory_append_mihawk = " openpower-fru-vpd openpower-occ-control virtual/obmc-gpio-presence id-button phosphor-cooling-type phosphor-gpu"
 RDEPENDS_${PN}-fan-control_append_ibm-ac-server = " witherspoon-fan-watchdog"
 RDEPENDS_${PN}-extras_append_ibm-ac-server = " witherspoon-pfault-analysis witherspoon-power-supply-sync phosphor-webui"
-RDEPENDS_${PN}-extras_append_mihawk = " phosphor-webui phosphor-image-signing witherspoon-pfault-analysis witherspoon-power-supply-sync"
+RDEPENDS_${PN}-extras_append_mihawk = " phosphor-webui phosphor-image-signing witherspoon-pfault-analysis"
 
 ${PN}-software-extras_append_ibm-ac-server = " phosphor-software-manager-sync"

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mihawk/obmc/power-supply-monitor/power-supply-monitor-0.conf
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mihawk/obmc/power-supply-monitor/power-supply-monitor-0.conf
@@ -1,6 +1,3 @@
 DEVPATH=/sys/bus/i2c/devices/3-005b
 INSTANCE=0
 INVENTORY=/system/chassis/motherboard/powersupply0
-NUM_HISTORY_RECORDS=120
-SYNC_GPIO_PATH=/dev/gpiochip0
-SYNC_GPIO_NUM=55

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mihawk/obmc/power-supply-monitor/power-supply-monitor-1.conf
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mihawk/obmc/power-supply-monitor/power-supply-monitor-1.conf
@@ -1,6 +1,3 @@
 DEVPATH=/sys/bus/i2c/devices/3-0058
 INSTANCE=1
 INVENTORY=/system/chassis/motherboard/powersupply1
-NUM_HISTORY_RECORDS=120
-SYNC_GPIO_PATH=/dev/gpiochip0
-SYNC_GPIO_NUM=55

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mihawk/pseq-monitor.service
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mihawk/pseq-monitor.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Power Sequencer Runtime Monitor
+Wants=obmc-host-start-pre@0.target
+Before=obmc-host-start-pre@0.target
+After=obmc-power-on@0.target
+Conflicts=obmc-chassis-poweroff@0.target
+
+[Service]
+ExecStart=/usr/bin/env pseq-monitor -a mihawk-cpld-runtime-monitor -i 500
+SyslogIdentifier=pseq-monitor

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/swift/pseq-monitor.service
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/swift/pseq-monitor.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Power Sequencer Runtime Monitor
+Wants=obmc-host-start-pre@0.target
+Before=obmc-host-start-pre@0.target
+After=obmc-power-on@0.target
+Conflicts=obmc-chassis-poweroff@0.target
+
+[Service]
+ExecStart=/usr/bin/env pseq-monitor -a runtime-monitor -i 500
+SyslogIdentifier=pseq-monitor

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/witherspoon/pseq-monitor.service
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/witherspoon/pseq-monitor.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Power Sequencer Runtime Monitor
+Wants=obmc-host-start-pre@0.target
+Before=obmc-host-start-pre@0.target
+After=obmc-power-on@0.target
+Conflicts=obmc-chassis-poweroff@0.target
+
+[Service]
+ExecStart=/usr/bin/env pseq-monitor -a runtime-monitor -i 500
+SyslogIdentifier=pseq-monitor

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis_git.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis_git.bb
@@ -32,8 +32,8 @@ SEQ_PGOOD_FMT = "../${SEQ_PGOOD_SVC}:${CHASSIS_ON_TGT}.wants/${SEQ_PGOOD_SVC}"
 
 SYSTEMD_SERVICE_${PN}_append_ibm-ac-server += "${SEQ_MONITOR_SVC} ${SEQ_PGOOD_SVC}"
 SYSTEMD_LINK_${PN}_append_ibm-ac-server += "${SEQ_MONITOR_FMT} ${SEQ_PGOOD_FMT}"
-SYSTEMD_SERVICE_${PN}_append_mihawk += "${SEQ_PGOOD_SVC}"
-SYSTEMD_LINK_${PN}_append_mihawk += "${SEQ_PGOOD_FMT}"
+SYSTEMD_SERVICE_${PN}_append_mihawk += "${SEQ_MONITOR_SVC} ${SEQ_PGOOD_SVC}"
+SYSTEMD_LINK_${PN}_append_mihawk += "${SEQ_MONITOR_FMT} ${SEQ_PGOOD_FMT}"
 
 PSU_MONITOR_TMPL = "power-supply-monitor@.service"
 PSU_MONITOR_INSTFMT = "power-supply-monitor@{0}.service"


### PR DESCRIPTION
1. Fix patch error:
commit 39eed9fc1c7baccca3e4ae17a16f045baf9d6096
Fix psu-driver error, and re-pull request to OP940.
Because this part is still reviewed in the upstream,
we're going to release the new version,
we create a patch of it in OP940 first.
We'll remove this patch after the upstream review passes.
https://www.spinics.net/lists/kernel/msg3339443.html 

2. Remove psu-sync function & add pseq-monitor for mihawk:
commit 77cee448fa196405bda17debe1003a5c111f9464
 2.1 Remove psu-sync function for mihawk.
 2.2 Add pseq-monitor for mihawk via modifying 
       witherspoon-pfault-analysis_git.bb.


Signed-off-by: Andy YF Wang <Andy_YF_Wang@wistron.com>