### PR TITLE
meta-ibm: Change the order of avsbus-disable

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/chassis/avsbus-control/mihawk/avsbus-disable@.service
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/chassis/avsbus-control/mihawk/avsbus-disable@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Disable the AVS bus on the VRMs
-Wants=op-power-start@.service
-After=op-power-start@.service
+Wants=ir35221-on-unbind@%i.service
+After=ir35221-on-unbind@%i.service
 Before=avsbus-enable@%i.service
 Conflicts=obmc-chassis-poweroff@%i.target
 ConditionPathExists=!/run/openbmc/chassis@%i-on

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/chassis/avsbus-control/mihawk/avsbus-enable@.service
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/chassis/avsbus-control/mihawk/avsbus-enable@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Enable the AVS bus on VRMs
-Wants=avsbus-disable@%i.service
-After=avsbus-disable@%i.service
+Wants=op-power-start@.service
+After=op-power-start@.service
 Conflicts=obmc-chassis-poweroff@%i.target
 ConditionPathExists=!/run/openbmc/chassis@%i-on
 


### PR DESCRIPTION
Currently avsbus-disable will be executed after power_up to 1.
We found that this will cause power on fail, so avsbus-disable should
be performed before power on.

https://gerrit.openbmc-project.xyz/c/openbmc/meta-ibm/+/28167