### PR TITLE
linux-aspeed: Update Linux to final v5.3

### DIFF
--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_git.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_git.bb
@@ -1,6 +1,6 @@
 KBRANCH ?= "dev-5.3"
-LINUX_VERSION ?= "5.3.1"
+LINUX_VERSION ?= "5.3.15"
 
-SRCREV="7e560ad8594fa4b7ae4417721c45116f8b785ca4"
+SRCREV="fdc60468f3e452364d432f1a7c3f83d58bba1b84"
 
 require linux-aspeed.inc


### PR DESCRIPTION
5.3 includes a number of fixes that OP940 needs.

Signed-off-by: Eddie James <eajames@linux.ibm.com>