### PR TITLE
lockout after failed root authentication

### DIFF
--- a/meta-phosphor/recipes-extended/pam/libpam/pam.d/common-auth
+++ b/meta-phosphor/recipes-extended/pam/libpam/pam.d/common-auth
@@ -8,7 +8,7 @@
 # traditional Unix authentication mechanisms.
 
 # here are the per-package modules (the "Primary" block)
-auth	[success=ok user_unknown=ignore default=2]	pam_tally2.so deny=5 unlock_time=300
+auth	[success=ok user_unknown=ignore default=2]	pam_tally2.so deny=5 unlock_time=300 even_deny_root root_unlock_time=300
 # Try for local user first, and then try for ldap
 auth	[success=2 default=ignore]	pam_unix.so quiet
 -auth    [success=1 default=ignore]  	pam_ldap.so ignore_unknown_user ignore_authinfo_unavail


### PR DESCRIPTION
This patch apples the 300 second account lockout policy to the root user account; the root account will have the same default behavior as other user accounts.  Specifically: Lockout authentication for 5 minutes after 5 failed authentication attempts.

The behavior of the pam_tally2 module (as configured here) is:
- The account is locked out after 5 or more unsuccessful authentication attempts.  (This is tracked per user.)
- When an account is locked out, no authentication attempts will succeed until the 5 minutes has elapsed.  Any subsequent attempts will reset the lockout period.  Only a successful authentication will clear the lockout.

Note that the AccountLockoutThreshold and AccountLockoutDuration properties in the Redfish AccountService do not apply to the root user, and there are no APIs to change the root account lockout policy.
_____

Tested: Yes, tested locking and timeout for both root and non-root.

This is a re-work of PR 80 ~ https://github.com/ibm-openbmc/openbmc/pull/80