### PR TITLE
meta-ibm: Add dev_id.json for mihawk

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/phosphor-ipmi-config/mihawk/dev_id.json
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/phosphor-ipmi-config/mihawk/dev_id.json
@@ -1,0 +1,2 @@
+{"id": 0, "revision": 128, "addn_dev_support": 141,
+    "manuf_id": 42817, "prod_id": 1, "aux": 0}


### PR DESCRIPTION
Currently mihawk is missing information about dev id.

(From meta-ibm rev: 28bafefc05285df52eab617ea2158b3886dc93a8)

https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/29223

Change-Id: I02b138a1830e0c4627c70b338d31cb7dbaa2d75c
Signed-off-by: Ben Pai <Ben_Pai@wistron.com>
Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>