### PR TITLE
meta-ibm: Add BMC EEPROM

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/vpd/mihawk-openpower-fru-inventory/inventory
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/vpd/mihawk-openpower-fru-inventory/inventory
@@ -1,3 +1,3 @@
-FRUS=ETHERNET,ETHERNET1
-PATHS=/system/chassis/motherboard/bmc/eth0,/system/chassis/motherboard/bmc/eth1
+FRUS=ETHERNET,ETHERNET1,BMC
+PATHS=/system/chassis/motherboard/bmc/eth0,/system/chassis/motherboard/bmc/eth1,/system/chassis/motherboard/bmc
 EEPROM=/sys/devices/platform/ahb/ahb:apb/ahb:apb:bus@1e78a000/1e78a340.i2c-bus/i2c-8/8-0050/eeprom


### PR DESCRIPTION
Added the BMC inventory for mihawk.

(From meta-ibm rev: 95efbf1fdb48951294a3832137d4c1a56fcab3a2)

https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/29726

Change-Id: I3478e33ce305324d2041e69d79d8873585cae23d
Signed-off-by: Ben Pai <Ben_Pai@wistron.com>
Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>