### PR TITLE
Add NVMe thermal senor for mihawk

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/nvme/phosphor-nvme.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/nvme/phosphor-nvme.bb
@@ -1,0 +1,26 @@
+PR = "r1"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${PHOSPHORBASE}/COPYING.apache-2.0;md5=34400b68072d710fecd0a2940a0d1658"
+
+inherit meson pkgconfig
+inherit obmc-phosphor-dbus-service
+inherit obmc-phosphor-systemd
+inherit phosphor-dbus-yaml
+inherit pythonnative
+
+DEPENDS += "sdbusplus"
+DEPENDS += "phosphor-dbus-interfaces"
+DEPENDS += "sdeventplus"
+DEPENDS += "phosphor-logging"
+DEPENDS += "sdbusplus-native"
+DEPENDS += "autoconf-archive-native"
+DEPENDS += "nlohmann-json"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI := "git://github.com/wistron-corporation/phosphor-nvme"
+SRCREV := "6682f07c169d8d83786c72b4a1ef3a1a64c57236"
+S = "${WORKDIR}/git"
+
+DBUS_SERVICE_${PN} = "xyz.openbmc_project.nvme.manager.service"
+

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/nvme/phosphor-nvme/xyz.openbmc_project.nvme.manager.service
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/nvme/phosphor-nvme/xyz.openbmc_project.nvme.manager.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=NVMe management
+After=nvme_gpio.service xyz.openbmc_project.LED.GroupManager.service
+
+[Service]
+ExecStart=/usr/bin/nvme_main
+Type=dbus
+BusName=xyz.openbmc_project.nvme.manager
+SyslogIdentifier=phosphor-nvme
+
+[Install]
+WantedBy=multi-user.target 

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
@@ -1,5 +1,5 @@
 RDEPENDS_${PN}-inventory_append_ibm-ac-server = " openpower-fru-vpd openpower-occ-control phosphor-cooling-type virtual/obmc-gpio-presence"
-RDEPENDS_${PN}-inventory_append_mihawk = " openpower-fru-vpd openpower-occ-control virtual/obmc-gpio-presence id-button phosphor-cooling-type phosphor-gpu"
+RDEPENDS_${PN}-inventory_append_mihawk = " openpower-fru-vpd openpower-occ-control virtual/obmc-gpio-presence id-button phosphor-cooling-type phosphor-gpu phosphor-nvme"
 RDEPENDS_${PN}-fan-control_append_ibm-ac-server = " witherspoon-fan-watchdog"
 RDEPENDS_${PN}-extras_append_ibm-ac-server = " witherspoon-pfault-analysis witherspoon-power-supply-sync phosphor-webui"
 RDEPENDS_${PN}-extras_append_mihawk = " phosphor-webui phosphor-image-signing witherspoon-pfault-analysis"


### PR DESCRIPTION
Mihawk will support NVMe thermal sensor.

The existing phosphor-nvme has many differences from mihawk's nvme. So I think it is difficult to merge.
Of course, we will still try to merge to phosphor-nvme in the future.