### PR TITLE
user-management: fixup file modes

### DIFF
--- a/meta-ibm/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
+++ b/meta-ibm/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
@@ -1,2 +1,3 @@
 RDEPENDS_${PN}-logging += "ibm-logging"
 RDEPENDS_${PN}-software += "nginx-prep-downgrade"
+RDEPENDS_${PN}-user-mgmt += "fixup-file-modes"

--- a/meta-phosphor/recipes-phosphor/ipmi/files/fixup-file-modes.service
+++ b/meta-phosphor/recipes-phosphor/ipmi/files/fixup-file-modes.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Fixup IPMI file modes
+After=network.target
+
+[Service]
+Restart=no
+Type=oneshot
+RemainAfterExit=true
+SyslogIdentifier=fixup-ipmi-files
+ExecStart=/bin/chmod 600 /etc/ipmi_pass /etc/key_file
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-phosphor/recipes-phosphor/ipmi/fixup-file-modes.bb
+++ b/meta-phosphor/recipes-phosphor/ipmi/fixup-file-modes.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Fixup ipmi file permissions"
+DESCRIPTION = "Fixup ipmi file permissions"
+PR = "r1"
+HOMEPAGE = "http://github.com/openbmc/meta-phosphor"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${IBMBASE}/COPYING.apache-2.0;md5=34400b68072d710fecd0a2940a0d1658"
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+inherit systemd
+inherit obmc-phosphor-systemd
+
+# Add a service to change the file modes (permission bits) for files
+# related to IPMI users.  Other users should have no access.
+# A service is needed (contrasted with changing the permissions in the
+# read-only firmware image) because the file may have been modified in
+# a read-write overlay, so a firmware update will not change the modes.
+
+# This service can be removed in the first release X where the
+# incorrect permissions are not set in any release along any upgrade
+# path to release X.
+
+SERVICE = "fixup-file-modes.service"
+SYSTEMD_SERVICE_${PN} += " ${SERVICE}"


### PR DESCRIPTION
Adds a service to fixup IPMI file modes so only the root user can access.
This is not yet fixed in upstream.

Tested:
- Service runs correctly per journalctl --unit=fixup-file-modes.
- Access via ipmitool works correctly.
- Changing password via ipmitool works correctly.
- Changing password via Redfish works correctly.
- Adding and removing user works correctly.
- File mode is not changed when user is modified.

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>