### PR TITLE
meta-ibm: Add mihawk ipmi oem command

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/wistron-ipmi-oem_git.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/wistron-ipmi-oem_git.bb
@@ -1,0 +1,23 @@
+SUMMARY = "Wistron OEM commands"
+DESCRIPTION = "Wistron OEM commands"
+HOMEPAGE = "https://github.com/openbmc/wistron-ipmi-oem"
+PR = "r1"
+PV = "0.1+git${SRCPV}"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=fa818a259cbed7ce8bc2a22d35a464fc"
+
+inherit autotools pkgconfig
+inherit obmc-phosphor-ipmiprovider-symlink
+
+DEPENDS += "phosphor-ipmi-host"
+DEPENDS += "autoconf-archive-native"
+
+S = "${WORKDIR}/git"
+SRC_URI = "git://github.com/openbmc/wistron-ipmi-oem"
+SRCREV = "44cee319dd113335a7885a1ff63a287dc7706682"
+
+FILES_${PN}_append = " ${libdir}/ipmid-providers/lib*${SOLIBS}"
+FILES_${PN}_append = " ${libdir}/host-ipmid/lib*${SOLIBS}"
+FILES_${PN}-dev_append = " ${libdir}/ipmid-providers/lib*${SOLIBSDEV} ${libdir}/ipmid-providers/*.la"
+
+HOSTIPMI_PROVIDER_LIBRARY += "libwistronoem.so"

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
@@ -2,6 +2,6 @@ RDEPENDS_${PN}-inventory_append_ibm-ac-server = " openpower-fru-vpd openpower-oc
 RDEPENDS_${PN}-inventory_append_mihawk = " openpower-fru-vpd openpower-occ-control virtual/obmc-gpio-presence id-button phosphor-cooling-type phosphor-gpu"
 RDEPENDS_${PN}-fan-control_append_ibm-ac-server = " witherspoon-fan-watchdog"
 RDEPENDS_${PN}-extras_append_ibm-ac-server = " witherspoon-pfault-analysis witherspoon-power-supply-sync phosphor-webui"
-RDEPENDS_${PN}-extras_append_mihawk = " phosphor-webui phosphor-image-signing witherspoon-pfault-analysis"
+RDEPENDS_${PN}-extras_append_mihawk = " phosphor-webui phosphor-image-signing witherspoon-pfault-analysis wistron-ipmi-oem"
 
 ${PN}-software-extras_append_ibm-ac-server = " phosphor-software-manager-sync"


### PR DESCRIPTION
In order to detect the riser card on the mihawk platform.

(From meta-ibm rev: a50f69fb50ab68137ce1b95d79ccb703c97e47c4)

Change-Id: Ief0019f08cc14f3733ba5db67fcf218f46812bb2
Signed-off-by: Ben Pai <Ben_Pai@wistron.com>
Signed-off-by: Andrew Geissler <geissonator@yahoo.com>