### PR TITLE
meta-ibm: Mihawk fan control support 250 soc thermal sensor

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/fans/phosphor-fan-control-events-config/mihawk/events.yaml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/fans/phosphor-fan-control-events-config/mihawk/events.yaml
@@ -174,6 +174,18 @@ groups:
           - /temperature/nvme21
           - /temperature/nvme22
           - /temperature/nvme23
+    - name: zone0_250soc
+      description: Group of 250soc temperature sensors for zone 0
+      type: /xyz/openbmc_project/sensors
+      members:
+          - /temperature/250_soc_temp0
+          - /temperature/250_soc_temp1
+          - /temperature/250_soc_temp2
+          - /temperature/250_soc_temp3
+          - /temperature/250_soc_temp4
+          - /temperature/250_soc_temp5
+          - /temperature/250_soc_temp6
+          - /temperature/250_soc_temp7
     - name: service_gpu
       description: Group of monitor gpu service
       type: /xyz/openbmc_project/sensors
@@ -775,3 +787,41 @@ events:
                           type: uint64_t
                 timer:
                     interval: 3
+              - name: speed_changes_based_on_250soc_temps
+                groups:
+                    - name: zone0_250soc
+                      zone_conditions:
+                          - name: air_cooled_chassis
+                            zones:
+                                - 0
+                      interface: xyz.openbmc_project.Sensor.Value
+                      property:
+                          name: Value
+                          type: int64_t
+                matches:
+                    - name: interfacesAdded
+                    - name: propertiesChanged
+                    - name: interfacesRemoved
+                actions:
+                    - name: set_net_increase_speed
+                      property:
+                          value: 80000
+                          type: int64_t
+                      factor:
+                          value: 1000
+                          type: int64_t
+                      delta:
+                          value: 13
+                          type: uint64_t
+                    - name: set_net_decrease_speed
+                      property:
+                          value: 77000
+                          type: int64_t
+                      factor:
+                          value: 3000
+                          type: int64_t
+                      delta:
+                          value: 5
+                          type: uint64_t
+                timer:
+                    interval: 1

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/fans/phosphor-fan-control-events-config/mihawk/events.yaml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/fans/phosphor-fan-control-events-config/mihawk/events.yaml
@@ -188,9 +188,9 @@ groups:
           - /temperature/250_soc_temp7
     - name: service_gpu
       description: Group of monitor gpu service
-      type: /xyz/openbmc_project/sensors
+      type: /xyz/openbmc_project/gpuservice
       members:
-          - /temperature/gpu0
+          - /status
 matches:
     - name: propertiesChanged
       description: >
@@ -363,10 +363,10 @@ events:
     - name: default_fan_floor_on_gpu_service_fail
       groups:
           - name: service_gpu
-            interface: xyz.openbmc_project.Sensor.Value
+            interface: xyz.openbmc_project.Inventory.Item
             property:
-                name: Value
-                type: int64_t
+                name: Present
+                type: bool
       matches:
           - name: nameOwnerChanged
       actions:

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/gpu/phosphor-gpu_git.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/gpu/phosphor-gpu_git.bb
@@ -19,7 +19,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 SRC_URI := "git://github.com/wistron-corporation/phosphor-gpu.git;protocol=git"
-SRCREV := "f634dc0677de4a4776f832c68685345634004820"
+SRCREV := "4488c740659130603636d783d895a5d5f965c806"
 S = "${WORKDIR}/git"
 
 DBUS_SERVICE_${PN} += "xyz.openbmc_project.gpu.manager.service"


### PR DESCRIPTION
Fan control must support 250 soc thermal sensor.

Tested: Fan speed is automatically controlled when using 250 soc

https://gerrit.openbmc-project.xyz/c/openbmc/openbmc/+/34724
(From meta-ibm rev: 05540e77d337f466bc339715153704edff3f6b88)

Change-Id: Ic17854a8556b5878bf506bfafd64762315390c39
Signed-off-by: Ben Pai <Ben_Pai@wistron.com>
Signed-off-by: Andrew Geissler <geissonator@yahoo.com>