### PR TITLE
Op940 add cronus service

### DIFF
--- a/meta-openpower/recipes-bsp/ecmd/croserver_git.bb
+++ b/meta-openpower/recipes-bsp/ecmd/croserver_git.bb
@@ -7,6 +7,8 @@ SRC_URI = "git://github.com/open-power/eCMD.git"
 SRCREV = "6c0348b12c95b3bd6e8d8003f9ff743d25400ae2"
 DEPENDS += "python-native zlib"
 
+SRC_URI += "file://croserver.service"
+
 S = "${WORKDIR}/git"
 
 # Add the hash style option here to Work around this warning:
@@ -26,4 +28,9 @@ do_compile() {
 do_install() {
     install -d ${D}${bindir}
     install -m 0755 out_obj/lib/server1p ${D}${bindir}/croserver
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/croserver.service ${D}${systemd_system_unitdir}/
 }
+
+FILES_${PN} += "${systemd_system_unitdir}/croserver.service"

--- a/meta-openpower/recipes-bsp/ecmd/croserver_git.bb
+++ b/meta-openpower/recipes-bsp/ecmd/croserver_git.bb
@@ -1,0 +1,29 @@
+SUMMARY = "eCMD"
+DESCRIPTION = "eCMD is a hardware access API for IBM Systems"
+LICENSE= "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${S}/NOTICE;md5=fee220301a2af3faf8f211524b4248ea"
+
+SRC_URI = "git://github.com/open-power/eCMD.git"
+SRCREV = "6c0348b12c95b3bd6e8d8003f9ff743d25400ae2"
+DEPENDS += "python-native zlib"
+
+S = "${WORKDIR}/git"
+
+# Add the hash style option here to Work around this warning:
+#   "QA Issue: No GNU_HASH in the elf binary"
+#
+# The recipe cannot set LDFLAGS in the environment as it overrides the
+# internal settings.
+do_configure() {
+   LD="${CXX} -Wl,--hash-style=gnu" ${S}/config.py --without-swig --output-root ${B} --target obj --extensions "cmd cip" --build-verbose
+}
+
+do_compile() {
+    cd ${S}/dllNetwork/server
+    oe_runmake
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 out_obj/lib/server1p ${D}${bindir}/croserver
+}

--- a/meta-openpower/recipes-bsp/ecmd/files/croserver.service
+++ b/meta-openpower/recipes-bsp/ecmd/files/croserver.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Cronus Server
+Documentation=https://github.com/open-power/eCMD/
+After=network.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/croserver
+Restart=on-failure
+ProtectHome=yes
+ProtectSystem=full
+RestrictAddressFamilies=AF_UNIX

--- a/meta-openpower/recipes-phosphor/packagegroups/packagegroup-op-apps.bb
+++ b/meta-openpower/recipes-phosphor/packagegroups/packagegroup-op-apps.bb
@@ -49,4 +49,5 @@ SUMMARY_${PN}-system = "OpenPOWER System"
 RDEPENDS_${PN}-system = " \
         hostboot-settings \
         pdbg \
+        croserver \
         "


### PR DESCRIPTION
These are pulled from upstream and add the cronus server to the BMC flash. Moving to the 5.4 kernel changed the FSI kernel interface so this commit packages in the cronus server that handles this change.