### PR TITLE
croserver bump 6c0348..46282c

### DIFF
--- a/meta-openpower/recipes-bsp/ecmd/croserver_git.bb
+++ b/meta-openpower/recipes-bsp/ecmd/croserver_git.bb
@@ -4,7 +4,7 @@ LICENSE= "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${S}/NOTICE;md5=fee220301a2af3faf8f211524b4248ea"
 
 SRC_URI = "git://github.com/open-power/eCMD.git"
-SRCREV = "6c0348b12c95b3bd6e8d8003f9ff743d25400ae2"
+SRCREV = "46282c03e686dfed51173e04eba06b96b2552401"
 DEPENDS += "python-native zlib"
 
 SRC_URI += "file://croserver.service"


### PR DESCRIPTION
Per Steven Janssen, this is the minimum bump required to satisfy
manufacturing test requirements.

Jason Albert (13):
      Add ecmdChipTarget hash support to pyapi
      Defined __deepcopy__ functions on classes
      Added python support for vector<vector<databuffer>>
      Fix python3 problems in config/build
      Fixed coredump due to accessing empty list
      Fix the __deepcopy__ implementation
      Force python 3 and updated logic around use of linux_distribution
      Big update to ecmdDllSpy.C
      Merge pull request #386 from thejta/spy-update
      Fixed in memory spy db performance
      Merge pull request #387 from thejta/spy-performance-update
      Added getSpyImages support
      Merge pull request #390 from thejta/spy-image-support

Joachim Fenkes (7):
      pyapi: Add support for vector<string> arguments
      pyecmd: Support list-of-string output arguments, some cleanup
      pyecmd: Extension support
      pyecmd: Add FAPI2 attribute get/set support, plus stub code for testing
      pyecmd: Make fapi2 test conditional on fapi2 being built into ecmd
      pyecmd: Data buffer improvements
      pyecmd: Check keyword arguments in Target constructor

Joel Stanley (3):
      Fix device paths again
      server: Fix linking
      Fix device paths again

Kahn Evans (58):
      Merge pull request #263 from thejta/deepcopy
      Merge pull request #266 from mklight/master
      Merge pull request #268 from mklight/spi_commands
      More complete use of ECMD_REMOVE_SCOM_FUNCTIONS compile flag Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>
      Merge pull request #270 from kahnevan/remove_scom_functions
      Merge pull request #274 from thejta/vector-vector
      Use chipUnitNum instead of core in targets Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>
      Merge pull request #278 from kahnevan/remove_core_use
      Resolve doxygen errors/warnings Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>
      Merge pull request #279 from kahnevan/doxygen_fixes
      Adding spy APIs to pass in multiple images. Adding ecmdQuerySpyRings() API to get all rings associated with spy and its parity checkers
      Updated query code as well
      Use const ecmdChipTargets in new APIs
      Merge pull request #281 from kahnevan/spy_maps
      update to version 14.19
      Merge pull request #282 from kahnevan/ecmd14_19
      Revert to checking all return codes instead of just a single one for non-enum retry. Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>
      Merge pull request #283 from kahnevan/fix_rc_check
      Syncing up with what's in Cronus Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>
      Merge pull request #287 from kahnevan/sync_with_cronus
      Merge pull request #286 from lkammath/new_flags
      Use system _AIX compile flag Signed-off-by: Kahn Evans <kahnevan@us.ibm.com>
      Merge pull request #290 from kahnevan/aix_compile_flag
      Merge pull request #296 from mklight/putmempba_cu_fix
      Merge pull request #309 from janssens2/mvpdupdate
      Merge pull request #313 from janssens2/targetupdate
      Adding empty file for ecmd15 compatibility.  Allows it to be included from install path in either release.
      Merge pull request #322 from thejta/python3-script-fixes
      Add optional -noignoremask flag to checkrings to skip application of ignoremask to read data
      Merge pull request #323 from kahnevan/checkrings_noignoremask
      Merge pull request #320 from kahnevan/dummy_file
      Merge pull request #317 from janssens2/getsramupdate
      Merge pull request #331 from janssens2/getsramfixtypo
      Merge pull request #333 from mklight/ecmdGetProcessingUnit
      Merge pull request #337 from thejta/coredump-fix
      Merge pull request #335 from janssens2/buffermod
      Merge pull request #343 from thejta/fix-deepcopy
      Merge pull request #348 from janssens2/generici2cslavetarget
      Merge pull request #325 from fenkes-ibm/pyecmd-extensions
      Merge pull request #307 from mklight/updated_target_rules
      Merge pull request #342 from mklight/fapi2_py_attr
      Add ecmdScomDataHidden lists for perl and python
      Merge pull request #354 from kahnevan/python_hidden_list_fix
      Sync up fapi2 files with ekb
      Add ecmd-core/pyecmd/__pycache__/ to .gitignore
      Merge pull request #362 from kahnevan/gitignore_update
      Merge pull request #360 from kahnevan/ekb_fapi2_sync
      Merge pull request #361 from thejta/update-config
      Merge pull request #372 from lkammath/python3_update
      Fix data input on gpr/fpr when using chip/chipunit input
      Merge pull request #374 from kahnevan/gpr_data_fix
      Fix for finding latch array entries in hash file in full lookup mode
      Merge pull request #378 from kahnevan/latch_array_hash_fix
      Merge pull request #382 from fenkes-ibm/pyecmd_databuffer
      Fixes for latch caching...it wasn't working right before
      Merge pull request #384 from kahnevan/latch_cache_fixes
      Update to valid owners/contacts
      Merge pull request #391 from kahnevan/owner_update

Lakshminarayana R. Kammath (2):
      Adding support for LDFLAGS and SLDFLAGS to pickup value from environment
      Use python3 env

Matt K. Light (33):
      BrkptInstruction server support
      update fapi2::ReturnCode
      get/putspi
      get/putspi links and htxt
      fix doxygen param name
      add start/stop/step support to BrkptInstruction
      add SERVER_BRKPT_SBE_PUTSCOM_ERROR error code
      fix serverlock authorization storage
      fix target for ecmdGetPbaUnit
      updated fapi2 target rules for z
      updated fsi device paths
      updated makefile
      Merge branch 'master' into BrkptInstruction
      fix duplicate RC
      move delay to its own source file
      enable SPIInstruction
      update ecmdGetProcessingUnit
      fix return code check in fapi2 subroutine executor
      support getting simple value fapi2 attributes from python
      support 1D fapi2 attributes from python
      support 2,3,4D fapi2 attributes from python
      fapi2GetAttr always returns rc and data, enable requesting dimensions with data
      add python fapi2SetAttr()
      Merge branch 'fapi2_py_attr' of https://github.com/fenkes-ibm/eCMD into fenkes-ibm-fapi2_py_attr
      add fapi2/capi dir to VPATH for dllStub
      Merge branch 'fenkes-ibm-fapi2_py_attr' into fapi2_py_attr
      remove pau-iohs relationship
      make fapi2 build optional for dllStub
      remove fapi2 from list of header files going to generate_pyecmd.py
      fix typo
      fapi2 buffer update
      enable support for fapi2::Target::reduceType()
      cipinstruct stop should call spwkup enable before stopping

Matt Light (12):
      Merge pull request #260 from thejta/target-hash-support
      Merge pull request #292 from mklight/fix_serverlock
      Merge pull request #299 from shenki/fsi-master-path
      Merge pull request #204 from mklight/BrkptInstruction
      Merge pull request #328 from mklight/SPIInstruction
      Merge pull request #340 from mklight/fix_subroutine_rc_check
      Merge pull request #345 from mklight/remove_relationship
      Merge pull request #2 from fenkes-ibm/fapi2_py_attr
      Merge pull request #357 from mklight/fapi2_buffer_update
      Merge pull request #356 from mklight/pyecmd_makefile_update
      Merge pull request #370 from mklight/reduce_type
      Merge pull request #376 from mklight/spwkup_cipinstruct_fix

Steven Janssen (9):
      add a mvpd keyword value
      additional target type added
      update to getsram to allow passing of a target and additional parameter handling
      fix a typo for command line processing
      update buffer methods
      addition of generici2cslave target information
      Update version to 14-20
      Merge pull request #353 from janssens2/ecmd14_20
      Update fsi locations for new bmc code

asangram (1):
      Merge pull request #388 from asangram/updateHtxt

sangram alapati (2):
      updated the help text for stopclocks
      updated the help text for stopclocks

Signed-off-by: Andrew Geissler <geisonator@yahoo.com>