### PR TITLE
kernel: bump up to 5.4.62

### DIFF
--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_git.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_git.bb
@@ -1,6 +1,6 @@
 KBRANCH ?= "dev-5.4"
-LINUX_VERSION ?= "5.4.53"
+LINUX_VERSION ?= "5.4.62"
 
-SRCREV="8a9b346382056b52cd7ff141ae9f15a0fcfeb13d"
+SRCREV="8033d00c74025312eb5ae32a46254aeddd114737"
 
 require linux-aspeed.inc


### PR DESCRIPTION
Picks up max31785 fan driver workaround

Signed-off-by: Andrew Geissler <geisonator@yahoo.com>