### PR TITLE
pdbg: Move to v3.0

### DIFF
--- a/meta-openpower/recipes-bsp/pdbg/pdbg_3.0.bb
+++ b/meta-openpower/recipes-bsp/pdbg/pdbg_3.0.bb
@@ -3,15 +3,15 @@ DESCRIPTION = "pdbg allows JTAG-like debugging of the host POWER processors"
 LICENSE     = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
-PV = "2.1+git${SRCPV}"
+PV = "3.0+git${SRCPV}"
 
 SRC_URI += "git://github.com/open-power/pdbg.git"
-SRC_URI += "file://proc-thread-control-chipop-based.patch"
-
-SRCREV = "dbbb35af951e36cb1ff134bdf74a5346d316e782"
+SRCREV = "v3.0"
 
 DEPENDS += "dtc-native"
 
 S = "${WORKDIR}/git"
 
 inherit autotools
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
    The 3.0 release follows from the 2.5-rc1. The changelog for 3.0 is as
    follows:

    Major upstream change was the split out the access method from the
    device-tree representation to enable backend agnostic system device
    trees.

    Other notable features:

    - Swift support
    - get/putmempba
    - Added SBEFIFO backend
    - Expanded use of SBEFIFO chipops