### PR TITLE
openpower-software-manager: Add 940 PNOR MSL level

### DIFF
--- a/meta-openpower/recipes-phosphor/flash/openpower-software-manager_git.bb
+++ b/meta-openpower/recipes-phosphor/flash/openpower-software-manager_git.bb
@@ -20,7 +20,7 @@ PACKAGECONFIG[verify_pnor_signature] = "--enable-verify_pnor_signature,--disable
 PACKAGECONFIG[ubifs_layout] = "--enable-ubifs_layout,--disable-ubifs_layout,,mtd-utils-ubifs"
 
 EXTRA_OECONF += " \
-    PNOR_MSL="v2.0.10 v2.2" \
+    PNOR_MSL="v2.0.10 v2.2 v2.4.1" \
     "
 
 DEPENDS += " \


### PR DESCRIPTION
Add the 940 PNOR level as the Minimum Ship Level.

Change-Id: I7c438b3689e0928bf3f3572cc6ac2cb9920b884b
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>