### PR TITLE
phosphor-dump-monitor- Fix failure for not finding core dump path

### DIFF
--- a/meta-phosphor/recipes-phosphor/dump/phosphor-debug-collector/obmc-dump-monitor.service
+++ b/meta-phosphor/recipes-phosphor/dump/phosphor-debug-collector/obmc-dump-monitor.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Phosphor Dump core monitor.
+ConditionPathExists=/var/lib/systemd/coredump
 
 [Service]
 ExecStart=/usr/bin/env phosphor-dump-monitor


### PR DESCRIPTION
phosphot-dump-monitor adds watch on systemd core dump path to
detect any new core files created to initiate a dump. On some
systems systemd core dump package is not pulled, due to this
phosphor-dump monitor service logs error and tries retry for 3 times.

Modified to start phosphor-dump-monitor service only when the
systed core dump path exists.

Tried to add Requires on systedm core dump service but as it is
a template version going with path approach.

Tested:
1) Removed systemd dump folder and restarted dump-monitor service
and ensured that there are no errors logged

(From meta-phosphor rev: 7a99220eaae763113372477c3d25039284802ef7)

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: Ibeb83cde454bf4c6fc6c6827a25705649ceaabe5
Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>