### PR TITLE
phosphor-mrw-tools srcrev bump 715c97ea..3d7698c2

### DIFF
--- a/meta-phosphor/classes/mrw-rev.bbclass
+++ b/meta-phosphor/classes/mrw-rev.bbclass
@@ -2,4 +2,4 @@ MRW_API_SRC_URI ?= "git://github.com/open-power/serverwiz.git"
 MRW_API_SRCREV ?= "60c8e10cbb11768cd1ba394b35cb1d6627efec42"
 
 MRW_TOOLS_SRC_URI ?= "git://github.com/openbmc/phosphor-mrw-tools"
-MRW_TOOLS_SRCREV ?= "715c97ea76bb6c976e57dfa899f76a7106a7c2d5"
+MRW_TOOLS_SRCREV ?= "3d7698c2be703ffbc78bb6cbb66186fbc6f06d37"


### PR DESCRIPTION
gen_ipmi_sensor: Add occ path conversion conditions for one CPU

When the platform has only one CPU, the occ inventory path will be
/system/chassis/motherboard/cpu/occ.
So checkOccPathFixup cannot be successfully converted to the correct
application d-bus path.

https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-mrw-tools/+/37463