### PR TITLE
wistron-ipmi-oem: srcrev bump 44cee319dd..ba89a1ea57

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/wistron-ipmi-oem_git.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/wistron-ipmi-oem_git.bb
@@ -14,7 +14,7 @@ DEPENDS += "autoconf-archive-native"
 
 S = "${WORKDIR}/git"
 SRC_URI = "git://github.com/openbmc/wistron-ipmi-oem"
-SRCREV = "44cee319dd113335a7885a1ff63a287dc7706682"
+SRCREV = "ba89a1ea570cb010c2e929ac11ada3714878ca7d"
 
 FILES_${PN}_append = " ${libdir}/ipmid-providers/lib*${SOLIBS}"
 FILES_${PN}_append = " ${libdir}/host-ipmid/lib*${SOLIBS}"


### PR DESCRIPTION
Ben Pai (1):
      Add wistron oem command to switch 250 soc image

(From meta-ibm rev: 3aa9904064a954031fac32b462c26c0b6d541ef1)

Change-Id: I6cc97288c35a1ac1f97f55ad0fe179dce9636bb0
Signed-off-by: Andrew Geissler <openbmcbump-github@yahoo.com>
Signed-off-by: Andrew Geissler <geissonator@yahoo.com>