### PR TITLE
Implement power-fault-monitor in Mowgli

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
@@ -4,6 +4,6 @@ RDEPENDS_${PN}-inventory_append_mowgli = " openpower-fru-vpd openpower-occ-contr
 RDEPENDS_${PN}-fan-control_append_ibm-ac-server = " witherspoon-fan-watchdog"
 RDEPENDS_${PN}-extras_append_ibm-ac-server = " witherspoon-pfault-analysis witherspoon-power-supply-sync phosphor-webui"
 RDEPENDS_${PN}-extras_append_mihawk = " phosphor-webui phosphor-image-signing witherspoon-pfault-analysis wistron-ipmi-oem"
-RDEPENDS_${PN}-extras_append_mowgli = " phosphor-webui phosphor-image-signing phosphor-misc usb-network"
+RDEPENDS_${PN}-extras_append_mowgli = " phosphor-webui phosphor-image-signing phosphor-misc usb-network witherspoon-pfault-analysis"
 
 ${PN}-software-extras_append_ibm-ac-server = " phosphor-software-manager-sync"

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mowgli/obmc/power-supply-monitor/power-supply-monitor-0.conf
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mowgli/obmc/power-supply-monitor/power-supply-monitor-0.conf
@@ -1,0 +1,3 @@
+DEVPATH=/sys/bus/i2c/devices/3-0068
+INSTANCE=0
+INVENTORY=/system/chassis/motherboard/powersupply0

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mowgli/obmc/power-supply-monitor/power-supply-monitor-1.conf
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mowgli/obmc/power-supply-monitor/power-supply-monitor-1.conf
@@ -1,0 +1,3 @@
+DEVPATH=/sys/bus/i2c/devices/3-0069
+INSTANCE=1
+INVENTORY=/system/chassis/motherboard/powersupply1

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mowgli/pseq-monitor-pgood.service
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mowgli/pseq-monitor-pgood.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Power Sequencer Power-on Monitor
+Wants=op-power-start@0.service
+After=op-power-start@0.service
+Wants=power-workarounds@0.service
+After=power-workarounds@0.service
+Conflicts=obmc-chassis-poweroff@0.target
+ConditionPathExists=!/run/openbmc/chassis@0-on
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/env pseq-monitor -a mihawk-cpld-pgood-monitor -i 5000
+SyslogIdentifier=pseq-monitor

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mowgli/pseq-monitor.service
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis/mowgli/pseq-monitor.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Power Sequencer Runtime Monitor
+Wants=obmc-host-start-pre@0.target
+Before=obmc-host-start-pre@0.target
+After=obmc-power-on@0.target
+Conflicts=obmc-chassis-poweroff@0.target
+
+[Service]
+ExecStart=/usr/bin/env pseq-monitor -a mihawk-cpld-runtime-monitor -i 500
+SyslogIdentifier=pseq-monitor

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis_git.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis_git.bb
@@ -31,8 +31,12 @@ SEQ_MONITOR_FMT = "../${SEQ_MONITOR_SVC}:${CHASSIS_ON_TGT}.wants/${SEQ_MONITOR_S
 SEQ_PGOOD_SVC = "pseq-monitor-pgood.service"
 SEQ_PGOOD_FMT = "../${SEQ_PGOOD_SVC}:${CHASSIS_ON_TGT}.wants/${SEQ_PGOOD_SVC}"
 
-SYSTEMD_SERVICE_${PN} += "${SEQ_MONITOR_SVC} ${SEQ_PGOOD_SVC}"
-SYSTEMD_LINK_${PN} += "${SEQ_MONITOR_FMT} ${SEQ_PGOOD_FMT}"
+SYSTEMD_SERVICE_${PN}_append_ibm-ac-server += "${SEQ_MONITOR_SVC} ${SEQ_PGOOD_SVC}"
+SYSTEMD_LINK_${PN}_append_ibm-ac-server += "${SEQ_MONITOR_FMT} ${SEQ_PGOOD_FMT}"
+SYSTEMD_SERVICE_${PN}_append_mihawk += "${SEQ_MONITOR_SVC} ${SEQ_PGOOD_SVC}"
+SYSTEMD_LINK_${PN}_append_mihawk += "${SEQ_MONITOR_FMT} ${SEQ_PGOOD_FMT}"
+SYSTEMD_SERVICE_${PN}_append_mowgli += "${SEQ_MONITOR_SVC} ${SEQ_PGOOD_SVC}"
+SYSTEMD_LINK_${PN}_append_mowgli += "${SEQ_MONITOR_FMT} ${SEQ_PGOOD_FMT}"
 
 PSU_MONITOR_TMPL = "power-supply-monitor@.service"
 PSU_MONITOR_INSTFMT = "power-supply-monitor@{0}.service"

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis_git.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis_git.bb
@@ -22,6 +22,7 @@ DEPENDS += " \
          "
 
 EXTRA_OECONF_append_ibm-ac-server = "UCD90160_DEF_YAML_FILE=${STAGING_DIR_HOST}${datadir}/power-sequencer/ucd90160.yaml"
+EXTRA_OECONF_append_mowgli = "MOWGLICPLD_DEVICE_ACCESS=yes"
 
 CHASSIS_ON_TGT = "obmc-chassis-poweron@0.target"
 SEQ_MONITOR_SVC = "pseq-monitor.service"
@@ -30,10 +31,8 @@ SEQ_MONITOR_FMT = "../${SEQ_MONITOR_SVC}:${CHASSIS_ON_TGT}.wants/${SEQ_MONITOR_S
 SEQ_PGOOD_SVC = "pseq-monitor-pgood.service"
 SEQ_PGOOD_FMT = "../${SEQ_PGOOD_SVC}:${CHASSIS_ON_TGT}.wants/${SEQ_PGOOD_SVC}"
 
-SYSTEMD_SERVICE_${PN}_append_ibm-ac-server += "${SEQ_MONITOR_SVC} ${SEQ_PGOOD_SVC}"
-SYSTEMD_LINK_${PN}_append_ibm-ac-server += "${SEQ_MONITOR_FMT} ${SEQ_PGOOD_FMT}"
-SYSTEMD_SERVICE_${PN}_append_mihawk += "${SEQ_MONITOR_SVC} ${SEQ_PGOOD_SVC}"
-SYSTEMD_LINK_${PN}_append_mihawk += "${SEQ_MONITOR_FMT} ${SEQ_PGOOD_FMT}"
+SYSTEMD_SERVICE_${PN} += "${SEQ_MONITOR_SVC} ${SEQ_PGOOD_SVC}"
+SYSTEMD_LINK_${PN} += "${SEQ_MONITOR_FMT} ${SEQ_PGOOD_FMT}"
 
 PSU_MONITOR_TMPL = "power-supply-monitor@.service"
 PSU_MONITOR_INSTFMT = "power-supply-monitor@{0}.service"


### PR DESCRIPTION
Implement power-fault-monitor in Mowgli.
Add Macro to distinguish Mihawk and Mowgli to ensure
that the part of code used by Mowgli can be built.

Signed-off-by: Andy YF Wang <Andy_YF_Wang@wistron.com>