### PR TITLE
meta-ibm: Power Restore Policy default to Restore

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/settings/phosphor-settings-manager/PowerRestorePolicy-default-restore.override.yml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/settings/phosphor-settings-manager/PowerRestorePolicy-default-restore.override.yml
@@ -1,0 +1,6 @@
+---
+/xyz/openbmc_project/control/host0/power_restore_policy:
+    - Interface: xyz.openbmc_project.Control.Power.RestorePolicy
+      Properties:
+          PowerRestorePolicy:
+             Default: RestorePolicy::Policy::Restore

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/settings/phosphor-settings-manager_%.bbappend
@@ -3,6 +3,7 @@ SRC_URI_append_ibm-ac-server = " file://TPMEnable-default-true.override.yml"
 SRC_URI_append_ibm-ac-server += " file://ClearHostSecurityKeys-default-zero.override.yml"
 SRC_URI_append_mihawk = " file://TPMEnable-default-true.override.yml"
 SRC_URI_append_mowgli = " file://TPMEnable-default-true.override.yml"
+SRC_URI_append_mowgli = " file://PowerRestorePolicy-default-restore.override.yml"
 # Provide a means to enable/disable openpower dbus linking
 DEPENDS += "openpower-dbus-interfaces openpower-dbus-interfaces-native"
 PACKAGECONFIG ??= "link-op-dbus-intfs"


### PR DESCRIPTION
Power Restore Policy default is set to Restore.

Signed-off-by: Ben Pai <Ben_Pai@wistron.com>