### PR TITLE
meta-ibm: To avoid usb ip is reset issue

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/network/network/0001-Let-usb-network-be-static-ip.patch
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/network/network/0001-Let-usb-network-be-static-ip.patch
@@ -1,0 +1,38 @@
+From c1e37528b159878d96fc77864b38fac5992bcc28 Mon Sep 17 00:00:00 2001
+From: Ben Pai <ben_pai@wistron.com>
+Date: Wed, 27 Jan 2021 13:59:29 +0800
+Subject: [PATCH] Let usb network be static ip
+
+---
+ util.cpp | 2 ++
+ util.hpp | 1 +
+ 2 files changed, 3 insertions(+)
+
+diff --git a/util.cpp b/util.cpp
+index fbf923a..d469ebe 100644
+--- a/util.cpp
++++ b/util.cpp
+@@ -264,6 +264,8 @@ std::string toString(const InAddrAny& addr)
+ 
+ bool isLinkLocalIP(const std::string& address)
+ {
++    if(address == USB_NETWORK)
++        return 0;
+     return address.find(IPV4_PREFIX) == 0 || address.find(IPV6_PREFIX) == 0;
+ }
+ 
+diff --git a/util.hpp b/util.hpp
+index cf59cbb..83b7802 100644
+--- a/util.hpp
++++ b/util.hpp
+@@ -24,6 +24,7 @@ constexpr auto IPV4_MAX_PREFIX_LENGTH = 32;
+ constexpr auto IPV6_MAX_PREFIX_LENGTH = 64;
+ constexpr auto IPV4_PREFIX = "169.254";
+ constexpr auto IPV6_PREFIX = "fe80";
++constexpr auto USB_NETWORK = "169.254.95.120";
+ 
+ namespace mac_address
+ {
+-- 
+2.7.4
+

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/network/phosphor-network_%.bbappend
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/network/phosphor-network_%.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/network:"
 SRC_URI_append_ibm-ac-server = " file://ncsi-netlink.service"
 SRC_URI_append_mihawk = " file://ncsi-netlink.service"
+SRC_URI_append_mowgli = " file://0001-Let-usb-network-be-static-ip.patch"
 
 SYSTEMD_SERVICE_${PN}_append_ibm-ac-server = " ncsi-netlink.service"
 SYSTEMD_SERVICE_${PN}_append_mihawk = " ncsi-netlink.service"


### PR DESCRIPTION
We found that the usb0 ip will be cleared when swtiching the ip mode
between DHCP and Static.
As long as the ip starting with "169.254", the ip mode will be regarded
as linklocal.
Because the usb0 ip of mowgli is 169.254.95.120, we need to add this
this special condition to avoid this issue.

Signed-off-by: Ben Pai <Ben_Pai@wistron.com>