### PR TITLE
meta-ibm: Remove usb0 from channel config

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/phosphor-ipmi-config/mowgli/channel_config.json
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/phosphor-ipmi-config/mowgli/channel_config.json
@@ -33,13 +33,13 @@
     }
   },
   "3" : {
-    "name" : "usb0",
-    "is_valid" : true,
+    "name" : "RESERVED",
+    "is_valid" : false,
     "active_sessions" : 0,
     "channel_info" : {
-      "medium_type" : "lan-802.3",
-      "protocol_type" : "ipmb-1.0",
-      "session_supported" : "multi-session",
+      "medium_type" : "reserved",
+      "protocol_type" : "na",
+      "session_supported" : "session-less",
       "is_ipmi" : true
     }
   },


### PR DESCRIPTION
Because the usb ip of HMC os will not be changed by the user, the usb0
of bmc must also be hidden.

Signed-off-by: Ben Pai <Ben_Pai@wistron.com>