### PR TITLE
Op940 5.4.119 kernel bump

### DIFF
--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed_git.bb
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed_git.bb
@@ -1,6 +1,6 @@
 KBRANCH ?= "dev-5.4"
-LINUX_VERSION ?= "5.4.62"
+LINUX_VERSION ?= "5.4.119"
 
-SRCREV="8033d00c74025312eb5ae32a46254aeddd114737"
+SRCREV="43e79c6defc55f9c0e3190aa2c2ed0bd1b704e07"
 
 require linux-aspeed.inc

--- a/poky/meta/lib/oe/utils.py
+++ b/poky/meta/lib/oe/utils.py
@@ -387,7 +387,7 @@ def host_gcc_version(d, taskcontextonly=False):
     except subprocess.CalledProcessError as e:
         bb.fatal("Error running %s --version: %s" % (compiler, e.output.decode("utf-8")))
 
-    match = re.match(r".* (\d\.\d)\.\d.*", output.split('\n')[0])
+    match = re.match(r".* (\d+\.\d+)\.\d+.*", output.split('\n')[0])
     if not match:
         bb.fatal("Can't get compiler version from %s --version output" % compiler)
 


### PR DESCRIPTION
I backported an upstream yocto fix (c301e66) so that OP940 can build on machines with gcc10.
The Linux bump moves us to the 5.4.119 Linux kernel which includes the latest security updates plus this fix from @eddiejames 

```
commit 8aab1a9ba269a3b012ee850ba7e33d09cb73000f
Author: Eddie James <eajames@linux.ibm.com>
Date:   Thu Apr 29 10:13:36 2021 -0500

    hwmon: (occ) Fix poll rate limiting
    
    The poll rate limiter time was initialized at zero. This breaks the
    comparison in time_after if jiffies is large. Switch to storing the
    next update time rather than the previous time, and initialize the
    time when the device is probed.
    
    Fixes: c10e753d43eb ("hwmon (occ): Add sensor types and versions")
    Signed-off-by: Eddie James <eajames@linux.ibm.com>
    Link: https://lore.kernel.org/r/20210429151336.18980-1-eajames@linux.ibm.com
    Signed-off-by: Joel Stanley <joel@jms.id.au>
```