### PR TITLE
meta-ibm: Add Model to asset interface

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/vpd/mihawk-openpower-fru-vpd-layout/layout.yaml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/vpd/mihawk-openpower-fru-vpd-layout/layout.yaml
@@ -3,6 +3,7 @@ BMC:
         OPFR,VP: PartNumber
         OPFR,VS: SerialNumber
         OPFR,VN: Manufacturer
+        VNDR,IN: Model
     xyz.openbmc_project.Inventory.Item:
         VINI,DR: PrettyName
     xyz.openbmc_project.Inventory.Item.Bmc:


### PR DESCRIPTION
The vendor data (VNDR) record is for vendor-specific data. The vendor
defines the data format within the IN keyword.

Tested: Finding Model in Inventory interface
- busctl introspect  xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/bmc

output:
 [[0;1;39mxyz.openbmc_project.Inventory.Decorator.Asset      [[0m interface -         -            -
 .BuildDate                                          property  s         ""           emits-change writable
 .Manufacturer                                       property  s         ""           emits-change writable
 .Model                                              property  s         "OEM"        emits-change writable
 .PartNumber                                         property  s         ""           emits-change writable
 .SerialNumber                                       property  s         ""           emits-change writable

Signed-off-by: Ben Pai <Ben_Pai@wistron.com>
Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>