### PR TITLE
meta-ibm: Mowgli's bmcweb only allows one KVM session

### DIFF
--- a/meta-ibm/recipes-phosphor/bmcweb/bmcweb/0001-Revert-Add-concurrent-KVM-sessions-support.patch
+++ b/meta-ibm/recipes-phosphor/bmcweb/bmcweb/0001-Revert-Add-concurrent-KVM-sessions-support.patch
@@ -1,0 +1,337 @@
+From 6cff61e9670f869247192138d62efa94d1e6c159 Mon Sep 17 00:00:00 2001
+From: LuluTHSu <Lulu_Su@wistron.com>
+Date: Thu, 5 Aug 2021 10:53:20 +0800
+Subject: [PATCH] Revert "Add concurrent KVM sessions support"
+
+This reverts commit 73926aebe40bc5d126ffec9ca34844322a5669b9.
+
+Reason for revert: IBM decided to not support multi-session of KVM on
+Mowgli.
+
+Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>
+---
+ include/kvm_websocket.hpp | 266 +++++++++++++++++++++++-----------------------
+ 1 file changed, 131 insertions(+), 135 deletions(-)
+
+diff --git a/include/kvm_websocket.hpp b/include/kvm_websocket.hpp
+index db42ab8..ae4d899 100644
+--- a/include/kvm_websocket.hpp
++++ b/include/kvm_websocket.hpp
+@@ -4,6 +4,7 @@
+ #include <sys/socket.h>
+ 
+ #include <boost/container/flat_map.hpp>
++#include <boost/container/flat_set.hpp>
+ #include <webserver_common.hpp>
+ 
+ namespace crow
+@@ -11,176 +12,171 @@ namespace crow
+ namespace obmc_kvm
+ {
+ 
+-static constexpr const uint maxSessions = 4;
++static std::unique_ptr<boost::asio::ip::tcp::socket> hostSocket;
+ 
+-class KvmSession
++// TODO(ed) validate that these buffer sizes are sane
++static boost::beast::flat_static_buffer<1024U * 50U> outputBuffer;
++static boost::beast::flat_static_buffer<1024U> inputBuffer;
++
++static crow::websocket::Connection* session = nullptr;
++
++static bool doingWrite = false;
++
++inline void doWrite();
++
++inline void WriteDone(const boost::system::error_code& ec,
++                      std::size_t bytesWritten)
+ {
+-  public:
+-    explicit KvmSession(crow::websocket::Connection& conn) :
+-        conn(conn), doingWrite(false), hostSocket(conn.get_io_context())
++    BMCWEB_LOG_DEBUG << "Wrote " << bytesWritten << "bytes";
++    doingWrite = false;
++    inputBuffer.consume(bytesWritten);
++
++    if (session == nullptr)
+     {
+-        boost::asio::ip::tcp::endpoint endpoint(
+-            boost::asio::ip::make_address("::1"), 5900);
+-        hostSocket.async_connect(
+-            endpoint, [this, &conn](const boost::system::error_code& ec) {
+-                if (ec)
+-                {
+-                    BMCWEB_LOG_ERROR
+-                        << "conn:" << &conn
+-                        << ", Couldn't connect to KVM socket port: " << ec;
+-                    if (ec != boost::asio::error::operation_aborted)
+-                    {
+-                        conn.close("Error in connecting to KVM port");
+-                    }
+-                    return;
+-                }
+-
+-                doRead();
+-            });
++        return;
+     }
+-
+-    void onMessage(const std::string& data)
++    if (ec == boost::asio::error::eof)
+     {
+-        if (data.length() > inputBuffer.capacity())
+-        {
+-            BMCWEB_LOG_ERROR << "conn:" << &conn
+-                             << ", Buffer overrun when writing "
+-                             << data.length() << " bytes";
+-            conn.close("Buffer overrun");
+-            return;
+-        }
+-
+-        BMCWEB_LOG_DEBUG << "conn:" << &conn << ", Read " << data.size()
+-                         << " bytes from websocket";
+-        boost::asio::buffer_copy(inputBuffer.prepare(data.size()),
+-                                 boost::asio::buffer(data));
+-        BMCWEB_LOG_DEBUG << "conn:" << &conn << ", Commiting " << data.size()
+-                         << " bytes from websocket";
+-        inputBuffer.commit(data.size());
+-
+-        BMCWEB_LOG_DEBUG << "conn:" << &conn << ", inputbuffer size "
+-                         << inputBuffer.size();
+-        doWrite();
++        session->close("KVM socket port closed");
++        return;
++    }
++    if (ec)
++    {
++        session->close("Error in reading to host port");
++        BMCWEB_LOG_ERROR << "Error in KVM socket write " << ec;
++        return;
+     }
+ 
+-  protected:
+-    void doRead()
++    doWrite();
++}
++
++inline void doWrite()
++{
++    if (doingWrite)
+     {
+-        std::size_t bytes = outputBuffer.capacity() - outputBuffer.size();
+-        BMCWEB_LOG_DEBUG << "conn:" << &conn << ", Reading " << bytes
+-                         << " from kvm socket";
+-        hostSocket.async_read_some(
+-            outputBuffer.prepare(outputBuffer.capacity() - outputBuffer.size()),
+-            [this](const boost::system::error_code& ec, std::size_t bytesRead) {
+-                BMCWEB_LOG_DEBUG << "conn:" << &conn << ", read done.  Read "
+-                                 << bytesRead << " bytes";
+-                if (ec)
+-                {
+-                    BMCWEB_LOG_ERROR
+-                        << "conn:" << &conn
+-                        << ", Couldn't read from KVM socket port: " << ec;
+-                    if (ec != boost::asio::error::operation_aborted)
+-                    {
+-                        conn.close("Error in connecting to KVM port");
+-                    }
+-                    return;
+-                }
+-
+-                outputBuffer.commit(bytesRead);
+-                std::string_view payload(
+-                    static_cast<const char*>(outputBuffer.data().data()),
+-                    bytesRead);
+-                BMCWEB_LOG_DEBUG << "conn:" << &conn
+-                                 << ", Sending payload size " << payload.size();
+-                conn.sendBinary(payload);
+-                outputBuffer.consume(bytesRead);
+-
+-                doRead();
+-            });
++        BMCWEB_LOG_DEBUG << "Already writing.  Bailing out";
++        return;
++    }
++    if (inputBuffer.size() == 0)
++    {
++        BMCWEB_LOG_DEBUG << "inputBuffer empty.  Bailing out";
++        return;
+     }
+ 
+-    void doWrite()
++    doingWrite = true;
++    hostSocket->async_write_some(inputBuffer.data(), WriteDone);
++}
++
++inline void doRead();
++
++inline void readDone(const boost::system::error_code& ec, std::size_t bytesRead)
++{
++    BMCWEB_LOG_DEBUG << "read done.  Read " << bytesRead << " bytes";
++    if (ec)
+     {
+-        if (doingWrite)
++        BMCWEB_LOG_ERROR << "Couldn't read from KVM socket port: " << ec;
++        if (session != nullptr)
+         {
+-            BMCWEB_LOG_DEBUG << "conn:" << &conn
+-                             << ", Already writing.  Bailing out";
+-            return;
++            session->close("Error in connecting to KVM port");
+         }
+-        if (inputBuffer.size() == 0)
++        return;
++    }
++    if (session == nullptr)
++    {
++        return;
++    }
++
++    outputBuffer.commit(bytesRead);
++    std::string_view payload(
++        static_cast<const char*>(outputBuffer.data().data()), bytesRead);
++    BMCWEB_LOG_DEBUG << "Sending payload size " << payload.size();
++    session->sendBinary(payload);
++    outputBuffer.consume(bytesRead);
++
++    doRead();
++}
++
++inline void doRead()
++{
++    std::size_t bytes = outputBuffer.capacity() - outputBuffer.size();
++    BMCWEB_LOG_DEBUG << "Reading " << bytes << " from kvm socket";
++    hostSocket->async_read_some(
++        outputBuffer.prepare(outputBuffer.capacity() - outputBuffer.size()),
++        readDone);
++}
++
++inline void connectHandler(const boost::system::error_code& ec)
++{
++    if (ec)
++    {
++        BMCWEB_LOG_ERROR << "Couldn't connect to KVM socket port: " << ec;
++        if (session != nullptr)
+         {
+-            BMCWEB_LOG_DEBUG << "conn:" << &conn
+-                             << ", inputBuffer empty.  Bailing out";
+-            return;
++            session->close("Error in connecting to KVM port");
+         }
+-
+-        doingWrite = true;
+-        hostSocket.async_write_some(
+-            inputBuffer.data(), [this](const boost::system::error_code& ec,
+-                                       std::size_t bytesWritten) {
+-                BMCWEB_LOG_DEBUG << "conn:" << &conn << ", Wrote "
+-                                 << bytesWritten << "bytes";
+-                doingWrite = false;
+-                inputBuffer.consume(bytesWritten);
+-
+-                if (ec == boost::asio::error::eof)
+-                {
+-                    conn.close("KVM socket port closed");
+-                    return;
+-                }
+-                if (ec)
+-                {
+-                    BMCWEB_LOG_ERROR << "conn:" << &conn
+-                                     << ", Error in KVM socket write " << ec;
+-                    if (ec != boost::asio::error::operation_aborted)
+-                    {
+-                        conn.close("Error in reading to host port");
+-                    }
+-                    return;
+-                }
+-
+-                doWrite();
+-            });
++        return;
+     }
+ 
+-    crow::websocket::Connection& conn;
+-    boost::asio::ip::tcp::socket hostSocket;
+-    boost::beast::flat_static_buffer<1024U * 50U> outputBuffer;
+-    boost::beast::flat_static_buffer<1024U> inputBuffer;
+-    bool doingWrite;
+-};
+-
+-static boost::container::flat_map<crow::websocket::Connection*,
+-                                  std::unique_ptr<KvmSession>>
+-    sessions;
++    doRead();
++}
+ 
+ inline void requestRoutes(CrowApp& app)
+ {
+-    sessions.reserve(maxSessions);
+-
+     BMCWEB_ROUTE(app, "/kvm/0")
+         .websocket()
+         .onopen([](crow::websocket::Connection& conn) {
+             BMCWEB_LOG_DEBUG << "Connection " << &conn << " opened";
+ 
+-            if (sessions.size() == maxSessions)
++            if (session != nullptr)
+             {
+-                conn.close("Max sessions are already connected");
++                conn.close("User already connected");
+                 return;
+             }
+ 
+-            sessions[&conn] = std::make_unique<KvmSession>(conn);
++            session = &conn;
++            if (hostSocket == nullptr)
++            {
++                boost::asio::ip::tcp::endpoint endpoint(
++                    boost::asio::ip::make_address("127.0.0.1"), 5900);
++
++                hostSocket = std::make_unique<boost::asio::ip::tcp::socket>(
++                    conn.get_io_context());
++                hostSocket->async_connect(endpoint, connectHandler);
++            }
+         })
+-        .onclose([](crow::websocket::Connection& conn,
+-                    const std::string& reason) { sessions.erase(&conn); })
++        .onclose(
++            [](crow::websocket::Connection& conn, const std::string& reason) {
++                session = nullptr;
++                hostSocket = nullptr;
++#if BOOST_VERSION >= 107000
++                inputBuffer.clear();
++                outputBuffer.clear();
++#else
++                inputBuffer.reset();
++                outputBuffer.reset();
++#endif
++            })
+         .onmessage([](crow::websocket::Connection& conn,
+                       const std::string& data, bool is_binary) {
+-            if (sessions[&conn])
++            if (data.length() > inputBuffer.capacity())
+             {
+-                sessions[&conn]->onMessage(data);
++                BMCWEB_LOG_ERROR << "Buffer overrun when writing "
++                                 << data.length() << " bytes";
++                conn.close("Buffer overrun");
++                return;
+             }
++
++            BMCWEB_LOG_DEBUG << "Read " << data.size()
++                             << " bytes from websocket";
++            boost::asio::buffer_copy(inputBuffer.prepare(data.size()),
++                                     boost::asio::buffer(data));
++            BMCWEB_LOG_DEBUG << "commiting " << data.size()
++                             << " bytes from websocket";
++            inputBuffer.commit(data.size());
++
++            BMCWEB_LOG_DEBUG << "inputbuffer size " << inputBuffer.size();
++            doWrite();
+         });
+ }
+-
+ } // namespace obmc_kvm
+ } // namespace crow
+-- 
+2.7.4
+

--- a/meta-ibm/recipes-phosphor/bmcweb/bmcweb_%.bbappend
+++ b/meta-ibm/recipes-phosphor/bmcweb/bmcweb_%.bbappend
@@ -2,3 +2,6 @@ EXTRA_OECMAKE_append = " \
     -DBMCWEB_INSECURE_ENABLE_REDFISH_FW_TFTP_UPDATE=ON \
     -DBMCWEB_INSECURE_DISABLE_CSRF_PREVENTION=ON \
 "
+
+FILESEXTRAPATHS_prepend_mowgli := "${THISDIR}/${PN}:"
+SRC_URI_append_mowgli = " file://0001-Revert-Add-concurrent-KVM-sessions-support.patch"


### PR DESCRIPTION
IBM decided to not support multi-session of KVM on Mowgli.

Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>