### PR TITLE
meta-ibm: Fix the KVM session patch of Mowgli

### DIFF
--- a/meta-ibm/recipes-phosphor/bmcweb/bmcweb/0001-Revert-Add-concurrent-KVM-sessions-support.patch
+++ b/meta-ibm/recipes-phosphor/bmcweb/bmcweb/0001-Revert-Add-concurrent-KVM-sessions-support.patch
@@ -1,4 +1,4 @@
-From 6cff61e9670f869247192138d62efa94d1e6c159 Mon Sep 17 00:00:00 2001
+From 31f0be36a7c5a87df160802bc85cc09cf340933b Mon Sep 17 00:00:00 2001
 From: LuluTHSu <Lulu_Su@wistron.com>
 Date: Thu, 5 Aug 2021 10:53:20 +0800
 Subject: [PATCH] Revert "Add concurrent KVM sessions support"
@@ -8,13 +8,16 @@ This reverts commit 73926aebe40bc5d126ffec9ca34844322a5669b9.
 Reason for revert: IBM decided to not support multi-session of KVM on
 Mowgli.
 
+Additional modification:
+- Add #161 to determine whether session exists, to avoid BMCweb crash.
+
 Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>
 ---
- include/kvm_websocket.hpp | 266 +++++++++++++++++++++++-----------------------
- 1 file changed, 131 insertions(+), 135 deletions(-)
+ include/kvm_websocket.hpp | 273 +++++++++++++++++++++++-----------------------
+ 1 file changed, 136 insertions(+), 137 deletions(-)
 
 diff --git a/include/kvm_websocket.hpp b/include/kvm_websocket.hpp
-index db42ab8..ae4d899 100644
+index db42ab8..8c8aaff 100644
 --- a/include/kvm_websocket.hpp
 +++ b/include/kvm_websocket.hpp
 @@ -4,6 +4,7 @@
@@ -25,7 +28,7 @@ index db42ab8..ae4d899 100644
  #include <webserver_common.hpp>
  
  namespace crow
-@@ -11,176 +12,171 @@ namespace crow
+@@ -11,176 +12,174 @@ namespace crow
  namespace obmc_kvm
  {
  
@@ -117,6 +120,11 @@ index db42ab8..ae4d899 100644
 +inline void doWrite()
 +{
 +    if (doingWrite)
++    {
++        BMCWEB_LOG_DEBUG << "Already writing.  Bailing out";
++        return;
++    }
++    if (inputBuffer.size() == 0)
      {
 -        std::size_t bytes = outputBuffer.capacity() - outputBuffer.size();
 -        BMCWEB_LOG_DEBUG << "conn:" << &conn << ", Reading " << bytes
@@ -149,11 +157,6 @@ index db42ab8..ae4d899 100644
 -
 -                doRead();
 -            });
-+        BMCWEB_LOG_DEBUG << "Already writing.  Bailing out";
-+        return;
-+    }
-+    if (inputBuffer.size() == 0)
-+    {
 +        BMCWEB_LOG_DEBUG << "inputBuffer empty.  Bailing out";
 +        return;
      }
@@ -308,25 +311,30 @@ index db42ab8..ae4d899 100644
          .onmessage([](crow::websocket::Connection& conn,
                        const std::string& data, bool is_binary) {
 -            if (sessions[&conn])
-+            if (data.length() > inputBuffer.capacity())
-             {
+-            {
 -                sessions[&conn]->onMessage(data);
-+                BMCWEB_LOG_ERROR << "Buffer overrun when writing "
-+                                 << data.length() << " bytes";
-+                conn.close("Buffer overrun");
-+                return;
-             }
+-            }
++			if (session != nullptr)
++			{
++				if (data.length() > inputBuffer.capacity())
++				{
++					BMCWEB_LOG_ERROR << "Buffer overrun when writing "
++									 << data.length() << " bytes";
++					conn.close("Buffer overrun");
++					return;
++				}
 +
-+            BMCWEB_LOG_DEBUG << "Read " << data.size()
-+                             << " bytes from websocket";
-+            boost::asio::buffer_copy(inputBuffer.prepare(data.size()),
-+                                     boost::asio::buffer(data));
-+            BMCWEB_LOG_DEBUG << "commiting " << data.size()
-+                             << " bytes from websocket";
-+            inputBuffer.commit(data.size());
++				BMCWEB_LOG_DEBUG << "Read " << data.size()
++								 << " bytes from websocket";
++				boost::asio::buffer_copy(inputBuffer.prepare(data.size()),
++										 boost::asio::buffer(data));
++				BMCWEB_LOG_DEBUG << "commiting " << data.size()
++								 << " bytes from websocket";
++				inputBuffer.commit(data.size());
 +
-+            BMCWEB_LOG_DEBUG << "inputbuffer size " << inputBuffer.size();
-+            doWrite();
++				BMCWEB_LOG_DEBUG << "inputbuffer size " << inputBuffer.size();
++				doWrite();
++			}
          });
  }
 -


### PR DESCRIPTION
Add a condition in onmessage to check whether the session exists, so as
to avoid BMCweb from crashing when multiple users try to use KVM at the
same time.

Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>