### PR TITLE
Add Fan VPD Data

### DIFF
--- a/meta-ibm/recipes-phosphor/vpd/ibm-vpd-parser/50001000.json
+++ b/meta-ibm/recipes-phosphor/vpd/ibm-vpd-parser/50001000.json
@@ -241,6 +241,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A0"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 0]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -250,6 +261,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A1"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 1]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -259,6 +281,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A2"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 2]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -268,6 +301,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A3"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 3]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -277,6 +321,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A4"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 4]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -286,6 +341,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A5"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 5]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },

--- a/meta-ibm/recipes-phosphor/vpd/ibm-vpd-parser/50001000_v2.json
+++ b/meta-ibm/recipes-phosphor/vpd/ibm-vpd-parser/50001000_v2.json
@@ -241,6 +241,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A0"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 0]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -250,6 +261,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A1"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 1]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -259,6 +281,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A2"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 2]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -268,6 +301,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A3"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 3]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -277,6 +321,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A4"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 4]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -286,6 +341,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A5"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 5]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },

--- a/meta-ibm/recipes-phosphor/vpd/ibm-vpd-parser/50001001.json
+++ b/meta-ibm/recipes-phosphor/vpd/ibm-vpd-parser/50001001.json
@@ -223,6 +223,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A0"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 55],
+              "CC": [55, 66, 53, 71]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 0]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5G",
+              "SparePartNumber": "02YK327"
           }
         }
       },
@@ -232,6 +243,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A1"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 55],
+              "CC": [55, 66, 53, 71]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 1]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5G",
+              "SparePartNumber": "02YK327"
           }
         }
       },
@@ -241,6 +263,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A2"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 55],
+              "CC": [55, 66, 53, 71]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 2]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5G",
+              "SparePartNumber": "02YK327"
           }
         }
       },
@@ -250,6 +283,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A3"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 55],
+              "CC": [55, 66, 53, 71]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 3]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5G",
+              "SparePartNumber": "02YK327"
           }
         }
       },
@@ -259,6 +303,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A4"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 55],
+              "CC": [55, 66, 53, 71]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 4]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5G",
+              "SparePartNumber": "02YK327"
           }
         }
       },
@@ -268,6 +323,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A5"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 55],
+              "CC": [55, 66, 53, 71]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 5]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5G",
+              "SparePartNumber": "02YK327"
           }
         }
       },

--- a/meta-ibm/recipes-phosphor/vpd/ibm-vpd-parser/50001001_v2.json
+++ b/meta-ibm/recipes-phosphor/vpd/ibm-vpd-parser/50001001_v2.json
@@ -223,6 +223,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A0"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 55],
+              "CC": [55, 66, 53, 71]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 0]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5G",
+              "SparePartNumber": "02YK327"
           }
         }
       },
@@ -232,6 +243,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A1"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 55],
+              "CC": [55, 66, 53, 71]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 1]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5G",
+              "SparePartNumber": "02YK327"
           }
         }
       },
@@ -241,6 +263,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A2"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 55],
+              "CC": [55, 66, 53, 71]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 2]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5G",
+              "SparePartNumber": "02YK327"
           }
         }
       },
@@ -250,6 +283,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A3"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 55],
+              "CC": [55, 66, 53, 71]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 3]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5G",
+              "SparePartNumber": "02YK327"
           }
         }
       },
@@ -259,6 +303,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A4"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 55],
+              "CC": [55, 66, 53, 71]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 4]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5G",
+              "SparePartNumber": "02YK327"
           }
         }
       },
@@ -268,6 +323,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A5"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 55],
+              "CC": [55, 66, 53, 71]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 5]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5G",
+              "SparePartNumber": "02YK327"
           }
         }
       },

--- a/meta-ibm/recipes-phosphor/vpd/ibm-vpd-parser/50001002.json
+++ b/meta-ibm/recipes-phosphor/vpd/ibm-vpd-parser/50001002.json
@@ -191,6 +191,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A0"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 0]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -200,6 +211,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A1"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 1]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -209,6 +231,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A2"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 2]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },
@@ -218,6 +251,17 @@
         "extraInterfaces": {
           "com.ibm.ipzvpd.Location" : {
               "LocationCode" : "Ufcs-A3"
+          },
+          "com.ibm.ipzvpd.VINI" : {
+              "FN": [48, 50, 89, 75, 51, 50, 51],
+              "CC": [55, 66, 53, 70]
+          },
+          "com.ibm.ipzvpd.DINF" : {
+              "RI": [0, 5, 33, 3]
+          },
+          "xyz.openbmc_project.Inventory.Decorator.Asset" : {
+              "Model": "7B5F",
+              "SparePartNumber": "02YK323"
           }
         }
       },


### PR DESCRIPTION
This commit adds fan VPD data to Rainier JSONs.
The Rainier fans do not have an eeprom and hence the need
to "hardcode" certain VPD needed by the hypervisor.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>