### PR TITLE
host-check: check host state on startup of host manager

### DIFF
--- a/meta-phosphor/recipes-core/systemd/obmc-targets.bb
+++ b/meta-phosphor/recipes-core/systemd/obmc-targets.bb
@@ -5,5 +5,12 @@ PR = "r1"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
-# TODO Will be removed once dependencies in other layers on this recipe are moved
-DEPENDS += "phosphor-state-manager"
+inherit allarch obmc-phosphor-systemd
+
+SRC_URI += "\
+    file://obmc-mapper.target \
+"
+
+SYSTEMD_SERVICE_${PN} += " \
+    obmc-mapper.target \
+"

--- a/meta-phosphor/recipes-core/systemd/obmc-targets/obmc-mapper.target
+++ b/meta-phosphor/recipes-core/systemd/obmc-targets/obmc-mapper.target
@@ -1,0 +1,4 @@
+[Unit]
+Description=Phosphor Object Mapper
+RefuseManualStart=yes
+RefuseManualStop=yes

--- a/meta-phosphor/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bb
+++ b/meta-phosphor/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bb
@@ -37,6 +37,7 @@ SUMMARY_${PN}-bmc-state-mgmt = "BMC state management"
 RDEPENDS_${PN}-bmc-state-mgmt = " \
         ${VIRTUAL-RUNTIME_obmc-bmc-state-manager} \
         phosphor-state-manager-systemd-target-monitor \
+        obmc-targets \
         "
 
 SUMMARY_${PN}-bmcweb = "bmcweb support"

--- a/meta-phosphor/recipes-phosphor/state/phosphor-state-manager-systemd-links.inc
+++ b/meta-phosphor/recipes-phosphor/state/phosphor-state-manager-systemd-links.inc
@@ -29,14 +29,6 @@ pkg_postinst_${PN}-obmc-targets_append() {
     ln -s $TARGET $LINK
 
     mkdir -p $D$systemd_system_unitdir/obmc-host-reset@0.target.requires
-    LINK="$D$systemd_system_unitdir/obmc-host-reset@0.target.requires/phosphor-reset-host-check@0.service"
-    TARGET="../phosphor-reset-host-check@.service"
-    ln -s $TARGET $LINK
-
-    LINK="$D$systemd_system_unitdir/obmc-host-reset@0.target.requires/phosphor-reset-sensor-states@0.service"
-    TARGET="../phosphor-reset-sensor-states@.service"
-    ln -s $TARGET $LINK
-
     LINK="$D$systemd_system_unitdir/obmc-host-reset@0.target.requires/phosphor-reset-host-running@0.service"
     TARGET="../phosphor-reset-host-running@.service"
     ln -s $TARGET $LINK
@@ -107,12 +99,6 @@ pkg_prerm_${PN}-obmc-targets_append() {
     rm $LINK
 
     LINK="$D$systemd_system_unitdir/obmc-host-stop@0.target.wants/phosphor-set-host-transition-to-off@0.service"
-    rm $LINK
-
-    LINK="$D$systemd_system_unitdir/obmc-host-reset@0.target.requires/phosphor-reset-host-check@0.service"
-    rm $LINK
-
-    LINK="$D$systemd_system_unitdir/obmc-host-reset@0.target.requires/phosphor-reset-sensor-states@0.service"
     rm $LINK
 
     LINK="$D$systemd_system_unitdir/obmc-host-stop@0.target.wants/phosphor-reset-sensor-states@0.service"

--- a/meta-phosphor/recipes-phosphor/state/phosphor-state-manager_git.bb
+++ b/meta-phosphor/recipes-phosphor/state/phosphor-state-manager_git.bb
@@ -82,7 +82,6 @@ FILES_${PN}-discover = "${bindir}/phosphor-discover-system-state"
 SYSTEMD_SERVICE_${PN}-discover += "phosphor-discover-system-state@.service"
 
 FILES_${PN}-host-check = "${bindir}/phosphor-host-check"
-SYSTEMD_SERVICE_${PN}-host-check += "phosphor-reset-host-check@.service"
 SYSTEMD_SERVICE_${PN}-host-check += "phosphor-reset-host-running@.service"
 
 SYSTEMD_SERVICE_${PN}-reset-sensor-states += "phosphor-reset-sensor-states@.service"
@@ -184,6 +183,6 @@ SYSTEMD_LINK_${PN}-obmc-targets += "${@compose_list(d, 'FAN_LINK_FMT', 'OBMC_CHA
 SYSTEMD_LINK_${PN}-obmc-targets += "${@compose_list(d, 'QUIESCE_FMT', 'HOST_ERROR_TARGETS', 'OBMC_HOST_INSTANCES')}"
 
 SRC_URI += "git://github.com/openbmc/phosphor-state-manager"
-SRCREV = "3ac78dfd6e3c6bf1c673e6acc8e6dc2deb6bd98b"
+SRCREV = "0d1c3f1f9329c853677f0581287afef83eeea0f0"
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/recipes-phosphor/state/phosphor-state-manager_git.bb
+++ b/meta-phosphor/recipes-phosphor/state/phosphor-state-manager_git.bb
@@ -163,7 +163,6 @@ QUIESCE_INSTFMT = "obmc-host-quiesce@{1}.target"
 QUIESCE_FMT = "../${QUIESCE_TMPL}:${CRASH_TIMEOUT_TGTFMT}.wants/${QUIESCE_INSTFMT}"
 
 SYSTEMD_SERVICE_${PN}-obmc-targets += " \
-        obmc-mapper.target \
         obmc-fans-ready.target \
         obmc-fan-control.target \
         obmc-fan-control-ready@.target \


### PR DESCRIPTION
See this commit for more info on function and testing:
 https://github.com/openbmc/phosphor-state-manager/commit/0d1c3f1f9329c853677f0581287afef83eeea0f0

phosphor-state-manager: srcrev bump 65bfcf5792..0d1c3f1f93

Andrew Geissler (1):
      host-check: discover host state within state manager

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>
Change-Id: I04129b1838118efceb1d073539d01d6e1af99eec