### PR TITLE
ibm-acf: Change location of public keys

### DIFF
--- a/meta-ibm/recipes-phosphor/ibm-acf/ibm-acf.bb
+++ b/meta-ibm/recipes-phosphor/ibm-acf/ibm-acf.bb
@@ -4,9 +4,11 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
 SRC_URI = "git://github.com/ibm-openbmc/ibm-acf"
-SRCREV = "aa639b9a6a608fe2095aeb93548177747a2aa859"
+SRCREV = "282f896795e7be7d4851597088e7095cbe2e4ca0"
 
 inherit meson
+#JSMN download required
+MESONOPTS:remove = " --wrap-mode nodownload "
 
 S = "${WORKDIR}/git"
 
@@ -19,7 +21,7 @@ DEPENDS = " \
 
 do_install:append(){
     install -d ${D}/${sysconfdir}/acf
-    install -m 755 ${WORKDIR}/git/subprojects/ce-login/p10-celogin-lab-pub.der \
+    install -m 755 ${S}/subprojects/ce-login/p10-celogin-lab-pub.der \
                    ${D}/${sysconfdir}/acf/ibmacf-dev.key
 }
 

--- a/meta-ibm/recipes-phosphor/ibm-acf/libpam_%.bbappend
+++ b/meta-ibm/recipes-phosphor/ibm-acf/libpam_%.bbappend
@@ -2,6 +2,7 @@ SERVICE_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'ibm-service-account-
 #Seach patterns within /etc/pam.d/common-* files
 COMMON_AUTH_PATTERN = "^auth.*success=3.*pam_unix.*"
 COMMON_ACCOUNT_PATTERN = "^account.*success=2.*pam_unix.*"
+COMMON_PASSWORD_PATTERN = "^password.*success=ok.*default=die.*pam_pwquality.so.*"
 COMMON_SESSION_PATTERN = "^session.*default.*pam_permit.*"
 #Intended to break if pam config has unexpected changes on referenced lines/files
 do_install:append() {
@@ -14,32 +15,40 @@ do_install:append() {
         #and fail if the pattern doesn't match
         grep -q ${COMMON_AUTH_PATTERN}  ${D}${sysconfdir}/pam.d/common-auth || err=$?
         if [ "$err" != "0" ]; then
-            echo "ERROR: command-auth file changed, breaking to ensure pam config is intended..."
+            echo "ERROR: common-auth file changed, breaking to ensure pam config is intended..."
             echo "exit $err"
             exit $err
         else
             #increment pam_tally2.so default=n+1 as we are inserting pam_ibmacf after it
-            sed -i.bak "s/auth.*default.*pam_tally2.*/auth [success=ok user_unknown=ignore default=3] pam_tally2.so deny=0 unlock_time=0/g" ${D}${sysconfdir}/pam.d/common-auth
-            sed -i.bak "/${COMMON_AUTH_PATTERN}/i auth [success=4 default=die ignore=ignore] pam_ibmacf.so" ${D}${sysconfdir}/pam.d/common-auth
+            sed -i.bak "/${COMMON_AUTH_PATTERN}/i auth [success=4 default=2 ignore=ignore] pam_ibmacf.so" ${D}${sysconfdir}/pam.d/common-auth
         fi
 
         grep -q ${COMMON_ACCOUNT_PATTERN} ${D}${sysconfdir}/pam.d/common-account || err=$?
         if [ "$err" != "0" ]; then
-            echo "ERROR: command-account file changed, breaking to ensure pam config is intended..."
+            echo "ERROR: common-account file changed, breaking to ensure pam config is intended..."
             echo "exit $err"
             exit $err
         else
-            sed -i.bak "/pam_unix.*/i account [success=3 default=die ignore=ignore] pam_ibmacf.so" ${D}${sysconfdir}/pam.d/common-account
+            sed -i.bak "/pam_unix.*/i account [success=3 default=ignore] pam_ibmacf.so" ${D}${sysconfdir}/pam.d/common-account
         fi
 
         grep -q ${COMMON_SESSION_PATTERN} ${D}${sysconfdir}/pam.d/common-session || err=$?
         if [ "$err" != "0" ]; then
-            echo "ERROR: command-session file changed, breaking to ensure pam config is intended..."
+            echo "ERROR: common-session file changed, breaking to ensure pam config is intended..."
             echo "exit $err"
             exit $err
         else
             sed -i.bak "/${COMMON_SESSION_PATTERN}/i session required pam_ibmacf.so" ${D}${sysconfdir}/pam.d/common-session
         fi
+        grep -q ${COMMON_PASSWORD_PATTERN} ${D}${sysconfdir}/pam.d/common-password || err=$?
+        if [ "$err" != "0" ]; then
+            echo "ERROR: common-password file changed, breaking to ensure pam config is intended..."
+            echo "exit $err"
+            exit $err
+        else
+            sed -i.bak "/${COMMON_PASSWORD_PATTERN}/i password [success=ignore default=die] pam_ibmacf.so" ${D}${sysconfdir}/pam.d/common-password
+        fi
+        rm ${D}${sysconfdir}/pam.d/common-*.bak
     fi
 
 }

--- a/meta-ibm/recipes-phosphor/images/obmc-phosphor-image.bbappend
+++ b/meta-ibm/recipes-phosphor/images/obmc-phosphor-image.bbappend
@@ -55,7 +55,6 @@ IBM_EXTRA_USERS_PARAMS += " \
 # Add the "service" account.
 IBM_EXTRA_USERS_PARAMS += " \
   useradd -M -d / --groups priv-admin,redfish,web,wheel service; \
-  usermod -p ${DEFAULT_OPENBMC_PASSWORD} service; \
   "
 
 # This is recipe specific to ensure it takes effect.


### PR DESCRIPTION
Moves location of public keys from /etc/acf/
to /srv/ibm-acf/