### PR TITLE
meta-aspeed: u-boot-aspeed-sdk: Ensure SOCSEC_SIGN defaults are set

### DIFF
--- a/meta-aspeed/recipes-bsp/u-boot/u-boot-aspeed-sdk_2019.04.bb
+++ b/meta-aspeed/recipes-bsp/u-boot/u-boot-aspeed-sdk_2019.04.bb
@@ -3,7 +3,6 @@ require u-boot-common-aspeed-sdk_${PV}.inc
 UBOOT_MAKE_TARGET ?= "DEVICE_TREE=${UBOOT_DEVICETREE}"
 
 require u-boot-aspeed.inc
-inherit socsec-sign
 
 PROVIDES += "u-boot"
 DEPENDS += "bc-native dtc-native"
@@ -17,6 +16,8 @@ SRC_URI += " \
 SOCSEC_SIGN_KEY ?= "${WORKDIR}/rsa_oem_dss_key.pem"
 SOCSEC_SIGN_ALGO ?= "RSA4096_SHA512"
 SOCSEC_SIGN_EXTRA_OPTS ?= "--stack_intersects_verification_region=false"
+
+inherit socsec-sign
 
 UBOOT_ENV_SIZE:df-phosphor-mmc = "0x10000"
 UBOOT_ENV:df-phosphor-mmc = "u-boot-env"


### PR DESCRIPTION
Include the socsec-sign class after the conditional assignments to
ensure the values we might assign are considered by the functions of
socsec-sign.

Without this, u-boot-aspeed-sdk do_deploy logs show:

```
DEBUG: Executing python function sstate_task_prefunc
DEBUG: Python function sstate_task_prefunc finished
DEBUG: Executing shell function do_deploy
Copying u-boot-nodtb binary...
Warning: Invalid socsec signing key - SPL verified boot won't be available
```

Adjusting the location of the include gives:

```
DEBUG: Executing python function sstate_task_prefunc
DEBUG: Python function sstate_task_prefunc finished
DEBUG: Executing shell function do_deploy
Copying u-boot-nodtb binary...
check header PASS
Found PEM header at position 381
check integrity PASS
```

Change-Id: I15cac4c315a6ceaeb69b0c02ba0b7d05e54f6e15
Signed-off-by: Andrew Jeffery <andrew@aj.id.au>