### PR TITLE
meta-ibm: Dynamically disable eth1.service

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/network/network/disableETH1.sh
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/network/network/disableETH1.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+SubModel=($(busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/bmc xyz.openbmc_project.Inventory.Decorator.Asset SubModel))
+echo "SubModel="${SubModel[1]}
+
+if [ "${SubModel[1]}" = '"ETH"' ]
+   then
+		echo "SubModel="${SubModel[1]}" was detected, so first-boot-set-mac@eth1.service is disabled"
+		systemctl disable first-boot-set-mac@eth1.service 
+fi

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/network/network/ncsi-netlink-mowgli.service
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/network/network/ncsi-netlink-mowgli.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Stop the ethernet link failover
+After=op-vpd-parser.service
+
+[Service]
+Restart=no
+ExecStart=/usr/bin/env ncsi-netlink --set -x 2 -p 0 -c 0
+ExecStartPost=sh /usr/bin/disableETH1.sh
+SyslogIdentifier=disableETH1.sh
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/network/phosphor-network_%.bbappend
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/network/phosphor-network_%.bbappend
@@ -1,12 +1,13 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/network:"
 SRC_URI_append_ibm-ac-server = " file://ncsi-netlink.service"
 SRC_URI_append_mihawk = " file://ncsi-netlink.service"
-SRC_URI_append_mowgli = " file://ncsi-netlink.service"
+SRC_URI_append_mowgli = " file://ncsi-netlink-mowgli.service"
+SRC_URI_append_mowgli = " file://disableETH1.sh"
 SRC_URI_append_mowgli = " file://0001-Let-usb-network-be-static-ip.patch"
 
 SYSTEMD_SERVICE_${PN}_append_ibm-ac-server = " ncsi-netlink.service"
 SYSTEMD_SERVICE_${PN}_append_mihawk = " ncsi-netlink.service"
-SYSTEMD_SERVICE_${PN}_append_mowgli = " ncsi-netlink.service"
+SYSTEMD_SERVICE_${PN}_append_mowgli = " ncsi-netlink-mowgli.service"
 
 do_install_append_ibm-ac-server() {
     install -d ${D}${systemd_system_unitdir}
@@ -18,5 +19,6 @@ do_install_append_mihawk() {
 }
 do_install_append_mowgli() {
     install -d ${D}${systemd_system_unitdir}
-    install -m 0644 ${WORKDIR}/ncsi-netlink.service ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/ncsi-netlink-mowgli.service ${D}${systemd_system_unitdir}
+    install -m 0755 ${WORKDIR}/disableETH1.sh ${D}/usr/bin
 }

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/vpd/mihawk-openpower-fru-vpd-layout/layout.yaml
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/vpd/mihawk-openpower-fru-vpd-layout/layout.yaml
@@ -4,6 +4,7 @@ BMC:
         OPFR,VS: SerialNumber
         OPFR,VN: Manufacturer
         VNDR,IN: Model
+        VINI,B3: SubModel
     xyz.openbmc_project.Inventory.Item:
         VINI,DR: PrettyName
     xyz.openbmc_project.Inventory.Item.Bmc:


### PR DESCRIPTION
The VPD B3 keyword in the VINI record is set to "ETH" to know that the
dedicated NIC has been removed.
If the "ETH" is detected, the unused services will be disabled:
first-boot-set-mac@eth1.service.

Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>