### PR TITLE
LEDS: Add systemd unit to call clear-all-faults.sh

### DIFF
--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/obmc-clear-all-fault-leds@.service
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/obmc-clear-all-fault-leds@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Clears all fault LED to %i
+After=obmc-chassis-powerreset@0.target
+Wants=obmc-power-reset-on@0.target
+After=obmc-power-reset-on@0.target
+ConditionPathExists=!/run/openbmc/chassis@0-on
+
+[Service]
+Type=oneshot
+Restart=no
+EnvironmentFile={envfiledir}/obmc/led/clear-all/faults/config
+ExecStart=/bin/bash -c "clear-all-fault-leds.sh %i ${{EXCLUDED_GROUPS}}"
+SyslogIdentifier=obmc-clear-all-fault-leds
+

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/obmc/led/clear-all/faults/config
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/obmc/led/clear-all/faults/config
@@ -1,0 +1,1 @@
+EXCLUDED_GROUPS=bmc_booted power_on _fault

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager_%.bbappend
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager_%.bbappend
@@ -10,6 +10,33 @@ SRC_URI:append:p10bmc = " \
     file://ibm,everest_associations.json \
     "
 
+SYSTEMD_SERVICE:${PN}:append:p10bmc += "obmc-clear-all-fault-leds@.service"
+
+# Copies config file having arguments for clear-all-fault-leds.sh
+SYSTEMD_ENVIRONMENT_FILE_${PN}:append:p10bmc +="obmc/led/clear-all/faults/config"
+
+pkg_postinst:${PN}:p10bmc () {
+    # Needed this to run as part of BMC boot
+    mkdir -p $D$systemd_system_unitdir/multi-user.target.wants
+    LINK_CLEAR="$D$systemd_system_unitdir/multi-user.target.wants/obmc-clear-all-fault-leds@true.service"
+    TARGET_CLEAR="../obmc-clear-all-fault-leds@.service"
+    ln -s $TARGET_CLEAR $LINK_CLEAR
+
+    # Needed this to run as part of Power On
+    mkdir -p $D$systemd_system_unitdir/obmc-chassis-poweron@0.target.wants
+    LINK_CLEAR="$D$systemd_system_unitdir/obmc-chassis-poweron@0.target.wants/obmc-clear-all-fault-leds@true.service"
+    TARGET_CLEAR="../obmc-clear-all-fault-leds@.service"
+    ln -s $TARGET_CLEAR $LINK_CLEAR
+}
+
+pkg_prerm:${PN}:p10bmc () {
+    LINK_CLEAR="$D$systemd_system_unitdir/multi-user.target.wants/obmc-clear-all-fault-leds@true.service"
+    rm $LINK_CLEAR
+
+    LINK_CLEAR="$D$systemd_system_unitdir/obmc-chassis-poweron@0.target.wants/obmc-clear-all-fault-leds@true.service"
+    rm $LINK_CLEAR
+}
+
 do_install:append:ibm-ac-server() {
     install -d ${D}${base_datadir}
     install -m 0755 ${WORKDIR}/associations.json ${D}${base_datadir}/associations.json


### PR DESCRIPTION
clear-all-faults.sh needs to be called with "true"
  - List all the inventory D-Bus objects implementing
    xyz.openbmc_project.State.Decorator.OperationalStatus
  - For each of those : set Functional property to true

Call those as part of below transitions
- BMC booting to standby and staying at standby
- BMC starting to power on
- 
For more details please refer ibm-openbmc/dev#3228

Signed-off-by: Lakshminarayana R. Kammath <lkammath@in.ibm.com>