### PR TITLE
Add support for hypervisor network configuration

### DIFF
--- a/meta-ibm/recipes-phosphor/network/phosphor-network_%.bbappend
+++ b/meta-ibm/recipes-phosphor/network/phosphor-network_%.bbappend
@@ -6,6 +6,9 @@ FILES:${PN} += "${datadir}/network/*.json"
 
 PACKAGECONFIG:append = " sync-mac"
 
+PACKAGECONFIG[hyp-nw-config] = "-Dhyp-nw-config=enabled, -Dhyp-nw-config=disabled,,"
+SYSTEMD_SERVICE_${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'hyp-nw-config', 'xyz.openbmc_project.Network.Hypervisor.service', '', d)}"
+
 install_network_configuration(){
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/ncsi-netlink.service ${D}${systemd_system_unitdir}


### PR DESCRIPTION
This commit is created based on the following change in
phosphor-networkd that creates an intermediate app
which takes care of hypervisor network configuration
from bmcweb and and updates the bios manager:
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-networkd/+/43173

A **PR** has already been created for **phosphor-networkd**
downstream repo:
https://github.com/ibm-openbmc/phosphor-networkd/pull/12

And a **PR** has been created for **bmcweb** downstream repo:
https://github.com/ibm-openbmc/bmcweb/pull/80

This feature(hyp-nw-config) is IBM specific and when
it is enabled, the service file gets created that starts
after the bios manager service.

It hosts the hypervisor network object that contains eth and
ip address objects which will have corresponding attributes
in the bios table.

The above gerrit commit will give further details on what this
application does.

Tested the same.