### PR TITLE
meta-ibm: Bump Minimum Firmware Level

### DIFF
--- a/meta-ibm/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-ibm/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -18,5 +18,5 @@ PACKAGECONFIG:append:ibm-ac-server = " sync_bmc_files"
 PACKAGECONFIG:append:mihawk = " sync_bmc_files"
 
 # Set BMC Minimum Ship Level
-EXTRA_OEMESON:append:p10bmc = " -Dbmc-msl='fw1020.00-25'"
+EXTRA_OEMESON:append:p10bmc = " -Dbmc-msl='fw1020.00-28'"
 EXTRA_OEMESON:append:p10bmc = " -Dregex-bmc-msl='([a-z]+[0-9]{2})+([0-9]+).([0-9]+).([0-9]+)'"


### PR DESCRIPTION
Bump to -28 since it has the u-boot secure boot support that is not
backward compatible.

Change-Id: I8424f79d184fe7d3dacb40b1586f2ae875716bb8
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>