### PR TITLE
dts: aspeed: rainier: Add system LEDs

### DIFF
--- a/meta-aspeed/recipes-kernel/linux/0001-leds-rainier-dts-update.patch
+++ b/meta-aspeed/recipes-kernel/linux/0001-leds-rainier-dts-update.patch
@@ -1,0 +1,1692 @@
+diff --git a/arch/arm/boot/dts/aspeed-bmc-ibm-rainier.dts b/arch/arm/boot/dts/aspeed-bmc-ibm-rainier.dts
+index 605ad80ef967..98e0019d325b 100644
+--- a/arch/arm/boot/dts/aspeed-bmc-ibm-rainier.dts
++++ b/arch/arm/boot/dts/aspeed-bmc-ibm-rainier.dts
+@@ -1098,6 +1098,62 @@  tmp275@4a {
+ 		reg = <0x4a>;
+ 	};
+ 
++	pca9551@60 {
++		compatible = "nxp,pca9551";
++		reg = <0x60>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		led@0 {
++			label = "cablecard0-cxp-top";
++			reg = <0>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@1 {
++			label = "cablecard0-cxp-bot";
++			reg = <1>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		gpio@2 {
++			reg = <2>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@3 {
++			reg = <3>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@4 {
++			reg = <4>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@5 {
++			reg = <5>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@6 {
++			reg = <6>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@7 {
++			reg = <7>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++	};
++
+ 	pca9546@70 {
+ 		compatible = "nxp,pca9546";
+ 		reg = <0x70>;
+@@ -1154,6 +1210,118 @@  tmp275@49 {
+ 		reg = <0x49>;
+ 	};
+ 
++	pca9551@60 {
++		compatible = "nxp,pca9551";
++		reg = <0x60>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		led@0 {
++			label = "cablecard3-cxp-top";
++			reg = <0>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@1 {
++			label = "cablecard3-cxp-bot";
++			reg = <1>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		gpio@2 {
++			reg = <2>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@3 {
++			reg = <3>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@4 {
++			reg = <4>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@5 {
++			reg = <5>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@6 {
++			reg = <6>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@7 {
++			reg = <7>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++	};
++
++	pca9551@61 {
++		compatible = "nxp,pca9551";
++		reg = <0x61>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		led@0 {
++			label = "cablecard4-cxp-top";
++			reg = <0>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@1 {
++			label = "cablecard4-cxp-bot";
++			reg = <1>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		gpio@2 {
++			reg = <2>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@3 {
++			reg = <3>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@4 {
++			reg = <4>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@5 {
++			reg = <5>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@6 {
++			reg = <6>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@7 {
++			reg = <7>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++	};
++
+ 	pca9546@70 {
+ 		compatible = "nxp,pca9546";
+ 		reg = <0x70>;
+@@ -1262,101 +1430,69 @@  &i2c7 {
+ 	multi-master;
+ 	status = "okay";
+ 
+-	si7021-a20@40 {
+-		compatible = "silabs,si7020";
+-		reg = <0x40>;
+-	};
+-
+-	tmp275@48 {
+-		compatible = "ti,tmp275";
+-		reg = <0x48>;
+-	};
+-
+-	max: max31785@52 {
+-		compatible = "maxim,max31785a";
+-		reg = <0x52>;
+-		#address-cells = <1>;
+-		#size-cells = <0>;
+-
+-		fan0: fan@0 {
+-			compatible = "pmbus-fan";
+-			reg = <0>;
+-			tach-pulses = <2>;
+-		};
+-
+-		fan1: fan@1 {
+-			compatible = "pmbus-fan";
+-			reg = <1>;
+-			tach-pulses = <2>;
+-		};
+-
+-		fan2: fan@2 {
+-			compatible = "pmbus-fan";
+-			reg = <2>;
+-			tach-pulses = <2>;
+-		};
+-
+-		fan3: fan@3 {
+-			compatible = "pmbus-fan";
+-			reg = <3>;
+-			tach-pulses = <2>;
+-		};
+-
+-		fan4: fan@4 {
+-			compatible = "pmbus-fan";
+-			reg = <4>;
+-			tach-pulses = <2>;
+-		};
+-
+-		fan5: fan@5 {
+-			compatible = "pmbus-fan";
+-			reg = <5>;
+-			tach-pulses = <2>;
+-		};
+-	};
+-
+-	pca0: pca9552@61 {
+-		compatible = "nxp,pca9552";
+-		reg = <0x61>;
++	pca9552@30 {
++		compatible = "ibm,pca9552";
++		reg = <0x30>;
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
+ 
+ 		gpio-controller;
+ 		#gpio-cells = <2>;
+ 
+-		gpio@0 {
++		led@0 {
++			label = "pcieslot0";
+ 			reg = <0>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@1 {
++		led@1 {
++			label = "pcieslot1";
+ 			reg = <1>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@2 {
++		led@2 {
++			label = "pcieslot2";
+ 			reg = <2>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@3 {
++		led@3 {
++			label = "pcieslot3";
+ 			reg = <3>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@4 {
++		led@4 {
++			label = "pcieslot4";
+ 			reg = <4>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@5 {
++		led@5 {
++			label = "cpu1";
+ 			reg = <5>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@6 {
++		led@6 {
++			label = "cpu-vrm1";
+ 			reg = <6>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+ 		gpio@7 {
+@@ -1364,9 +1500,12 @@  gpio@7 {
+ 			type = <PCA955X_TYPE_GPIO>;
+ 		};
+ 
+-		gpio@8 {
++		led@8 {
++			label = "lcd-russel";
+ 			reg = <8>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+ 		gpio@9 {
+@@ -1405,116 +1544,955 @@  gpio@15 {
+ 		};
+ 	};
+ 
+-	ibm-panel@62 {
+-		compatible = "ibm,op-panel";
+-		reg = <(0x62 | I2C_OWN_SLAVE_ADDRESS)>;
+-	};
++	pca9552@31 {
++		compatible = "ibm,pca9552";
++		reg = <0x31>;
++		#address-cells = <1>;
++		#size-cells = <0>;
+ 
+-	dps: dps310@76 {
+-		compatible = "infineon,dps310";
+-		reg = <0x76>;
+-		#io-channel-cells = <0>;
+-	};
++		gpio-controller;
++		#gpio-cells = <2>;
+ 
+-	eeprom@50 {
+-		compatible = "atmel,24c64";
+-		reg = <0x50>;
+-	};
++		led@0 {
++			label = "ddimm0";
++			reg = <0>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-	eeprom@51 {
+-		compatible = "atmel,24c64";
+-		reg = <0x51>;
+-	};
+-};
++		led@1 {
++			label = "ddimm1";
++			reg = <1>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-&i2c8 {
+-	status = "okay";
++		led@2 {
++			label = "ddimm2";
++			reg = <2>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-	ucd90320@11 {
+-		compatible = "ti,ucd90320";
+-		reg = <0x11>;
+-	};
++		led@3 {
++			label = "ddimm3";
++			reg = <3>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-	rtc@32 {
+-		compatible = "epson,rx8900";
+-		reg = <0x32>;
+-	};
++		led@4 {
++			label = "ddimm4";
++			reg = <4>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-	tmp275@48 {
+-		compatible = "ti,tmp275";
+-		reg = <0x48>;
+-	};
++		led@5 {
++			label = "ddimm5";
++			reg = <5>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-	tmp275@4a {
+-		compatible = "ti,tmp275";
+-		reg = <0x4a>;
+-	};
++		led@6 {
++			label = "ddimm6";
++			reg = <6>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@7 {
++			label = "ddimm7";
++			reg = <7>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@8 {
++			label = "ddimm8";
++			reg = <8>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@9 {
++			label = "ddimm9";
++			reg = <9>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@10 {
++			label = "ddimm10";
++			reg = <10>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@11 {
++			label = "ddimm11";
++			reg = <11>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@12 {
++			label = "ddimm12";
++			reg = <12>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@13 {
++			label = "ddimm13";
++			reg = <13>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@14 {
++			label = "ddimm14";
++			reg = <14>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@15 {
++			label = "ddimm15";
++			reg = <15>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++	};
++
++	pca9552@32 {
++		compatible = "ibm,pca9552";
++		reg = <0x32>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		led@0 {
++			label = "ddimm16";
++			reg = <0>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@1 {
++			label = "ddimm17";
++			reg = <1>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@2 {
++			label = "ddimm18";
++			reg = <2>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@3 {
++			label = "ddimm19";
++			reg = <3>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@4 {
++			label = "ddimm20";
++			reg = <4>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@5 {
++			label = "ddimm21";
++			reg = <5>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@6 {
++			label = "ddimm22";
++			reg = <6>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@7 {
++			label = "ddimm23";
++			reg = <7>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@8 {
++			label = "ddimm24";
++			reg = <8>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@9 {
++			label = "ddimm25";
++			reg = <9>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@10 {
++			label = "ddimm26";
++			reg = <10>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@11 {
++			label = "ddimm27";
++			reg = <11>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@12 {
++			label = "ddimm28";
++			reg = <12>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@13 {
++			label = "ddimm29";
++			reg = <13>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@14 {
++			label = "ddimm30";
++			reg = <14>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@15 {
++			label = "ddimm31";
++			reg = <15>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++	};
++
++	pca9552@33 {
++		compatible = "ibm,pca9552";
++		reg = <0x33>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		led@0 {
++			label = "planar";
++			reg = <0>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@1 {
++			label = "cpu0";
++			reg = <1>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		gpio@2 {
++			reg = <2>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		led@3 {
++			label = "dasd-pyramid0";
++			reg = <3>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@4 {
++			label = "dasd-pyramid1";
++			reg = <4>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@5 {
++			label = "dasd-pyramid2";
++			reg = <5>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@6 {
++			label = "cpu0-vrm0";
++			reg = <6>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@7 {
++			label = "rtc-battery";
++			reg = <7>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@8 {
++			label = "base-blyth";
++			reg = <8>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@9 {
++			label = "pcieslot6";
++			reg = <9>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@10 {
++			label = "pcieslot7";
++			reg = <10>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@11 {
++			label = "pcieslot8";
++			reg = <11>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@12 {
++			label = "pcieslot9";
++			reg = <12>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@13 {
++			label = "pcieslot10";
++			reg = <13>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@14 {
++			label = "pcieslot11";
++			reg = <14>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@15 {
++			label = "tpm-wilson";
++			reg = <15>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++	};
++
++	si7021-a20@40 {
++		compatible = "silabs,si7020";
++		reg = <0x40>;
++	};
++
++	tmp275@48 {
++		compatible = "ti,tmp275";
++		reg = <0x48>;
++	};
++
++	max: max31785@52 {
++		compatible = "maxim,max31785a";
++		reg = <0x52>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		fan0: fan@0 {
++			compatible = "pmbus-fan";
++			reg = <0>;
++			tach-pulses = <2>;
++		};
++
++		fan1: fan@1 {
++			compatible = "pmbus-fan";
++			reg = <1>;
++			tach-pulses = <2>;
++		};
++
++		fan2: fan@2 {
++			compatible = "pmbus-fan";
++			reg = <2>;
++			tach-pulses = <2>;
++		};
++
++		fan3: fan@3 {
++			compatible = "pmbus-fan";
++			reg = <3>;
++			tach-pulses = <2>;
++		};
++
++		fan4: fan@4 {
++			compatible = "pmbus-fan";
++			reg = <4>;
++			tach-pulses = <2>;
++		};
++
++		fan5: fan@5 {
++			compatible = "pmbus-fan";
++			reg = <5>;
++			tach-pulses = <2>;
++		};
++	};
++
++	pca0: pca9552@61 {
++		compatible = "nxp,pca9552";
++		reg = <0x61>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		led@0 {
++			label = "fan0";
++			reg = <0>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@1 {
++			label = "fan1";
++			reg = <1>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@2 {
++			label = "fan2";
++			reg = <2>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@3 {
++			label = "fan3";
++			reg = <3>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@4 {
++			label = "fan4";
++			reg = <4>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@5 {
++			label = "fan5";
++			reg = <5>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		gpio@6 {
++			reg = <6>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@7 {
++			reg = <7>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@8 {
++			reg = <8>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@9 {
++			reg = <9>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@10 {
++			reg = <10>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@11 {
++			reg = <11>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@12 {
++			reg = <12>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@13 {
++			reg = <13>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@14 {
++			reg = <14>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@15 {
++			reg = <15>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++	};
++
++	ibm-panel@62 {
++		compatible = "ibm,op-panel";
++		reg = <(0x62 | I2C_OWN_SLAVE_ADDRESS)>;
++	};
++
++	dps: dps310@76 {
++		compatible = "infineon,dps310";
++		reg = <0x76>;
++		#io-channel-cells = <0>;
++	};
++
++	eeprom@50 {
++		compatible = "atmel,24c64";
++		reg = <0x50>;
++	};
++
++	eeprom@51 {
++		compatible = "atmel,24c64";
++		reg = <0x51>;
++	};
++};
++
++&i2c8 {
++	status = "okay";
++
++	ucd90320@11 {
++		compatible = "ti,ucd90320";
++		reg = <0x11>;
++	};
++
++	rtc@32 {
++		compatible = "epson,rx8900";
++		reg = <0x32>;
++	};
++
++	tmp275@48 {
++		compatible = "ti,tmp275";
++		reg = <0x48>;
++	};
++
++	tmp275@4a {
++		compatible = "ti,tmp275";
++		reg = <0x4a>;
++	};
+ 
+ 	eeprom@50 {
+ 		compatible = "atmel,24c64";
+ 		reg = <0x50>;
+ 	};
+ 
+-	eeprom@51 {
++	eeprom@51 {
++		compatible = "atmel,24c64";
++		reg = <0x51>;
++	};
++
++	pca_pres2: pca9552@61 {
++		compatible = "nxp,pca9552";
++		reg = <0x61>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		gpio-line-names =
++			"SLOT6_PRSNT_EN_RSVD", "SLOT7_PRSNT_EN_RSVD",
++			"SLOT8_PRSNT_EN_RSVD", "SLOT9_PRSNT_EN_RSVD",
++			"SLOT10_PRSNT_EN_RSVD", "SLOT11_PRSNT_EN_RSVD",
++			"SLOT6_EXPANDER_PRSNT_N", "SLOT7_EXPANDER_PRSNT_N",
++			"SLOT8_EXPANDER_PRSNT_N", "SLOT9_EXPANDER_PRSNT_N",
++			"SLOT10_EXPANDER_PRSNT_N", "SLOT11_EXPANDER_PRSNT_N",
++			"", "", "", "";
++
++		gpio@0 {
++			reg = <0>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@1 {
++			reg = <1>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@2 {
++			reg = <2>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@3 {
++			reg = <3>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@4 {
++			reg = <4>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@5 {
++			reg = <5>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@6 {
++			reg = <6>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@7 {
++			reg = <7>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@8 {
++			reg = <8>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@9 {
++			reg = <9>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@10 {
++			reg = <10>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@11 {
++			reg = <11>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@12 {
++			reg = <12>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@13 {
++			reg = <13>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@14 {
++			reg = <14>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@15 {
++			reg = <15>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++	};
++
++};
++
++&i2c9 {
++	status = "okay";
++
++	tmp423a@4c {
++		compatible = "ti,tmp423";
++		reg = <0x4c>;
++	};
++
++	tmp423b@4d {
++		compatible = "ti,tmp423";
++		reg = <0x4d>;
++	};
++
++	eeprom@50 {
++		compatible = "atmel,24c128";
++		reg = <0x50>;
++	};
++};
++
++&i2c10 {
++	status = "okay";
++
++	tmp423a@4c {
++		compatible = "ti,tmp423";
++		reg = <0x4c>;
++	};
++
++	tmp423b@4d {
++		compatible = "ti,tmp423";
++		reg = <0x4d>;
++	};
++
++	eeprom@50 {
++		compatible = "atmel,24c128";
++		reg = <0x50>;
++	};
++};
++
++&i2c11 {
++	status = "okay";
++
++	tmp275@48 {
++		compatible = "ti,tmp275";
++		reg = <0x48>;
++	};
++
++	tmp275@49 {
++		compatible = "ti,tmp275";
++		reg = <0x49>;
++	};
++
++	pca9551@60 {
++		compatible = "nxp,pca9551";
++		reg = <0x60>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		led@0 {
++			label = "cablecard10-cxp-top";
++			reg = <0>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@1 {
++			label = "cablecard10-cxp-bot";
++			reg = <1>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		gpio@2 {
++			reg = <2>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@3 {
++			reg = <3>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@4 {
++			reg = <4>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@5 {
++			reg = <5>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@6 {
++			reg = <6>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@7 {
++			reg = <7>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++	};
++
++	pca9546@70 {
++		compatible = "nxp,pca9546";
++		reg = <0x70>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++		status = "okay";
++		i2c-mux-idle-disconnect;
++
++		i2c11mux0chn0: i2c@0 {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			reg = <0>;
++
++			eeprom@50 {
++				compatible = "atmel,24c64";
++				reg = <0x50>;
++			};
++		};
++
++		i2c11mux0chn1: i2c@1 {
++			#address-cells = <1>;
++			#size-cells = <0>;
++			reg = <1>;
++
++			eeprom@51 {
++				compatible = "atmel,24c64";
++				reg = <0x51>;
++			};
++		};
++	};
++};
++
++&i2c12 {
++	status = "okay";
++};
++
++&i2c13 {
++	status = "okay";
++
++	eeprom@50 {
+ 		compatible = "atmel,24c64";
+-		reg = <0x51>;
++		reg = <0x50>;
+ 	};
+ 
+-	pca_pres2: pca9552@61 {
++	pca9552@60 {
+ 		compatible = "nxp,pca9552";
+-		reg = <0x61>;
++		reg = <0x60>;
+ 		#address-cells = <1>;
+ 		#size-cells = <0>;
++
+ 		gpio-controller;
+ 		#gpio-cells = <2>;
+ 
+-		gpio-line-names =
+-			"SLOT6_PRSNT_EN_RSVD", "SLOT7_PRSNT_EN_RSVD",
+-			"SLOT8_PRSNT_EN_RSVD", "SLOT9_PRSNT_EN_RSVD",
+-			"SLOT10_PRSNT_EN_RSVD", "SLOT11_PRSNT_EN_RSVD",
+-			"SLOT6_EXPANDER_PRSNT_N", "SLOT7_EXPANDER_PRSNT_N",
+-			"SLOT8_EXPANDER_PRSNT_N", "SLOT9_EXPANDER_PRSNT_N",
+-			"SLOT10_EXPANDER_PRSNT_N", "SLOT11_EXPANDER_PRSNT_N",
+-			"", "", "", "";
+-
+-		gpio@0 {
++		led@0 {
++			label = "nvme0";
+ 			reg = <0>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@1 {
++		led@1 {
++			label = "nvme1";
+ 			reg = <1>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@2 {
++		led@2 {
++			label = "nvme2";
+ 			reg = <2>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@3 {
++		led@3 {
++			label = "nvme3";
+ 			reg = <3>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@4 {
++		led@4 {
++			label = "nvme4";
+ 			reg = <4>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@5 {
++		led@5 {
++			label = "nvme5";
+ 			reg = <5>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@6 {
++		led@6 {
++			label = "nvme6";
+ 			reg = <6>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		gpio@7 {
++		led@7 {
++			label = "nvme7";
+ 			reg = <7>;
+-			type = <PCA955X_TYPE_GPIO>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+ 		gpio@8 {
+@@ -1557,111 +2535,128 @@  gpio@15 {
+ 			type = <PCA955X_TYPE_GPIO>;
+ 		};
+ 	};
+-
+ };
+ 
+-&i2c9 {
++&i2c14 {
+ 	status = "okay";
+ 
+-	tmp423a@4c {
+-		compatible = "ti,tmp423";
+-		reg = <0x4c>;
+-	};
+-
+-	tmp423b@4d {
+-		compatible = "ti,tmp423";
+-		reg = <0x4d>;
+-	};
+-
+ 	eeprom@50 {
+-		compatible = "atmel,24c128";
++		compatible = "atmel,24c64";
+ 		reg = <0x50>;
+ 	};
+-};
+ 
+-&i2c10 {
+-	status = "okay";
++	pca9552@60 {
++		compatible = "nxp,pca9552";
++		reg = <0x60>;
++		#address-cells = <1>;
++		#size-cells = <0>;
+ 
+-	tmp423a@4c {
+-		compatible = "ti,tmp423";
+-		reg = <0x4c>;
+-	};
++		gpio-controller;
++		#gpio-cells = <2>;
+ 
+-	tmp423b@4d {
+-		compatible = "ti,tmp423";
+-		reg = <0x4d>;
+-	};
++		led@0 {
++			label = "nvme8";
++			reg = <0>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-	eeprom@50 {
+-		compatible = "atmel,24c128";
+-		reg = <0x50>;
+-	};
+-};
++		led@1 {
++			label = "nvme9";
++			reg = <1>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-&i2c11 {
+-	status = "okay";
++		led@2 {
++			label = "nvme10";
++			reg = <2>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-	tmp275@48 {
+-		compatible = "ti,tmp275";
+-		reg = <0x48>;
+-	};
++		led@3 {
++			label = "nvme11";
++			reg = <3>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-	tmp275@49 {
+-		compatible = "ti,tmp275";
+-		reg = <0x49>;
+-	};
++		led@4 {
++			label = "nvme12";
++			reg = <4>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-	pca9546@70 {
+-		compatible = "nxp,pca9546";
+-		reg = <0x70>;
+-		#address-cells = <1>;
+-		#size-cells = <0>;
+-		status = "okay";
+-		i2c-mux-idle-disconnect;
++		led@5 {
++			label = "nvme13";
++			reg = <5>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-		i2c11mux0chn0: i2c@0 {
+-			#address-cells = <1>;
+-			#size-cells = <0>;
+-			reg = <0>;
++		led@6 {
++			label = "nvme14";
++			reg = <6>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
+ 
+-			eeprom@50 {
+-				compatible = "atmel,24c64";
+-				reg = <0x50>;
+-			};
++		led@7 {
++			label = "nvme15";
++			reg = <7>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
+ 		};
+ 
+-		i2c11mux0chn1: i2c@1 {
+-			#address-cells = <1>;
+-			#size-cells = <0>;
+-			reg = <1>;
++		gpio@8 {
++			reg = <8>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
+ 
+-			eeprom@51 {
+-				compatible = "atmel,24c64";
+-				reg = <0x51>;
+-			};
++		gpio@9 {
++			reg = <9>;
++			type = <PCA955X_TYPE_GPIO>;
+ 		};
+-	};
+-};
+ 
+-&i2c12 {
+-	status = "okay";
+-};
++		gpio@10 {
++			reg = <10>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
+ 
+-&i2c13 {
+-	status = "okay";
++		gpio@11 {
++			reg = <11>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
+ 
+-	eeprom@50 {
+-		compatible = "atmel,24c64";
+-		reg = <0x50>;
+-	};
+-};
++		gpio@12 {
++			reg = <12>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
+ 
+-&i2c14 {
+-	status = "okay";
++		gpio@13 {
++			reg = <13>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
+ 
+-	eeprom@50 {
+-		compatible = "atmel,24c64";
+-		reg = <0x50>;
++		gpio@14 {
++			reg = <14>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@15 {
++			reg = <15>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
+ 	};
+ };
+ 
+@@ -1672,6 +2667,120 @@  eeprom@50 {
+ 		compatible = "atmel,24c64";
+ 		reg = <0x50>;
+ 	};
++
++	pca9552@60 {
++		compatible = "nxp,pca9552";
++		reg = <0x60>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		gpio-controller;
++		#gpio-cells = <2>;
++
++		led@0 {
++			label = "nvme16";
++			reg = <0>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@1 {
++			label = "nvme17";
++			reg = <1>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@2 {
++			label = "nvme18";
++			reg = <2>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@3 {
++			label = "nvme19";
++			reg = <3>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@4 {
++			label = "nvme20";
++			reg = <4>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@5 {
++			label = "nvme21";
++			reg = <5>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@6 {
++			label = "nvme22";
++			reg = <6>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		led@7 {
++			label = "nvme23";
++			reg = <7>;
++			retain-state-shutdown;
++			default-state = "keep";
++			type = <PCA955X_TYPE_LED>;
++		};
++
++		gpio@8 {
++			reg = <8>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@9 {
++			reg = <9>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@10 {
++			reg = <10>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@11 {
++			reg = <11>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@12 {
++			reg = <12>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@13 {
++			reg = <13>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@14 {
++			reg = <14>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++
++		gpio@15 {
++			reg = <15>;
++			type = <PCA955X_TYPE_GPIO>;
++		};
++	};
+ };
+ 
+ &vuart1 {
+

--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed.inc
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed.inc
@@ -12,6 +12,7 @@ SRC_URI += " \
              file://defconfig \
              file://rsa_oem_fitimage_key.key;sha256sum=eeb4ff2ebbfbd97b6254fe6dbaeea41067e54c65176c233ec7b2ab2decf1ddcd \
              file://rsa_oem_fitimage_key.crt;sha256sum=45f5a55497cce8040999bf9f3214d471ac7b83ab7acef41c4425a34662e8372e \
+             file://0001-leds-rainier-dts-update.patch \
            "
 
 LINUX_VERSION_EXTENSION ?= "-${SRCREV}"


### PR DESCRIPTION
Add all the missing system LEDs. These are all connected by GPIO
expanders.

Signed-off-by: Lakshminarayana R. Kammath <lkammath@in.ibm.com>