### PR TITLE
meta-ibm: Increase host console log to 256K

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/console/obmc-console/mihawk/obmc-console.conf
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/console/obmc-console/mihawk/obmc-console.conf
@@ -2,3 +2,4 @@ lpc-address = 0x3f8
 sirq = 4
 local-tty = ttyS0
 local-tty-baud = 115200
+logsize = 256k

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/console/obmc-console/mowgli/obmc-console.conf
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/console/obmc-console/mowgli/obmc-console.conf
@@ -2,3 +2,4 @@ lpc-address = 0x3f8
 sirq = 4
 local-tty = ttyS0
 local-tty-baud = 115200
+logsize = 256k


### PR DESCRIPTION
The host team has requested a bump in their allocated log size. ([link](https://github.com/open-power/ibm-wistron-collaboration/issues/12))
Increase the console log size of Mihawk and Mowgli from the default
16K to 256K.

Testing: Loaded on system and caused a lot of traffic in host console
and verified /var/log/obmc-console.log did not grow beyond 256K and
properly wrapped.

Signed-off-by: LuluTHSu <Lulu_Su@wistron.com>