### PR TITLE
meta-ibm: dbus-sensors: Install nvmesensor

### DIFF
--- a/meta-ibm/recipes-phosphor/sensors/dbus-sensors_%.bbappend
+++ b/meta-ibm/recipes-phosphor/sensors/dbus-sensors_%.bbappend
@@ -1,1 +1,5 @@
-PACKAGECONFIG:p10bmc = "hwmontempsensor iiosensor"
+PACKAGECONFIG:p10bmc = "hwmontempsensor iiosensor nvmesensor"
+
+SYSTEMD_SERVICE:${PN} += "${@bb.utils.contains('PACKAGECONFIG', 'nvmesensor', \
+                                               'xyz.openbmc_project.nvmesensor.service', \
+                                               '', d)}"


### PR DESCRIPTION
This needs to go in _after_ the package bump associated with merging ibm-openbmc/dbus-sensors#4 or rebasing ibm-openbmc/dbus-sensors against upstream.