### PR TITLE
Add rsyslog configuration for Redfish Event Log

### DIFF
--- a/meta-ibm/recipes-phosphor/rsyslog/rsyslog/rotate-event-logs.service
+++ b/meta-ibm/recipes-phosphor/rsyslog/rsyslog/rotate-event-logs.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Rotate the event logs
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/rotate-event-logs.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-ibm/recipes-phosphor/rsyslog/rsyslog/rotate-event-logs.sh
+++ b/meta-ibm/recipes-phosphor/rsyslog/rsyslog/rotate-event-logs.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+while true; do
+    sleep 60
+    /usr/sbin/logrotate /etc/logrotate.d/logrotate.rsyslog
+    ec=$?
+    if [ $ec -ne 0 ] ; then
+        echo "logrotate failed ($ec)"
+    fi
+done

--- a/meta-ibm/recipes-phosphor/rsyslog/rsyslog/rsyslog-override.conf
+++ b/meta-ibm/recipes-phosphor/rsyslog/rsyslog/rsyslog-override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecReload=/bin/kill -HUP $MAINPID

--- a/meta-ibm/recipes-phosphor/rsyslog/rsyslog/rsyslog.conf
+++ b/meta-ibm/recipes-phosphor/rsyslog/rsyslog/rsyslog.conf
@@ -1,0 +1,36 @@
+# if you experience problems, check
+# http://www.rsyslog.com/troubleshoot for assistance
+
+# rsyslog v3: load input modules
+# If you do not load inputs, nothing happens!
+# You may need to set the module load path if modules are not found.
+#
+# Ported from debian's sysklogd.conf
+
+# Journal-style logging
+# Limit to no more than 2000 entries in one minute and enable the
+# journal workaround to avoid duplicate entries
+module(load="imjournal" StateFile="/var/log/state"
+                        RateLimit.Interval="60"
+                        RateLimit.Burst="2000")
+
+# Template for Redfish messages
+# "<timestamp> <MessageId>,<MessageArgs>"
+template(name="RedfishTemplate" type="list") {
+    property(name="timereported" dateFormat="rfc3339")
+    constant(value=" ")
+    property(name="$!REDFISH_MESSAGE_ID")
+    constant(value=",")
+    property(name="$!REDFISH_MESSAGE_ARGS")
+    constant(value="\n")
+}
+
+# If the journal entry has a Redfish MessageId, save as a Redfish event
+if ($!REDFISH_MESSAGE_ID != "") then {
+   action(type="omfile" file="/var/log/redfish" template="RedfishTemplate")
+}
+
+#
+# Include all config files in /etc/rsyslog.d/
+#
+$IncludeConfig /etc/rsyslog.d/*.conf

--- a/meta-ibm/recipes-phosphor/rsyslog/rsyslog/rsyslog.logrotate
+++ b/meta-ibm/recipes-phosphor/rsyslog/rsyslog/rsyslog.logrotate
@@ -1,0 +1,12 @@
+# /etc/logrotate.d/rsyslog - Ported from Debian
+
+# Keep up to four 64k files for redfish (256k total)
+/var/log/redfish
+{
+    rotate 3
+    size 64k
+    missingok
+    postrotate
+        systemctl reload rsyslog 2> /dev/null || true
+    endscript
+}

--- a/meta-ibm/recipes-phosphor/rsyslog/rsyslog_%.bbappend
+++ b/meta-ibm/recipes-phosphor/rsyslog/rsyslog_%.bbappend
@@ -1,0 +1,23 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:p10bmc = "file://rsyslog.conf \
+                          file://rsyslog.logrotate \
+                          file://rotate-event-logs.service \
+                          file://rotate-event-logs.sh \
+                          file://rsyslog-override.conf \
+"
+FILES:${PN}:append:p10bmc = " ${systemd_system_unitdir}/rsyslog.service.d/rsyslog-override.conf"
+
+PACKAGECONFIG:append:p10bmc = " imjournal"
+
+do_install:append:p10bmc() {
+        install -m 0644 ${WORKDIR}/rotate-event-logs.service ${D}${systemd_system_unitdir}
+        install -d ${D}${systemd_system_unitdir}/rsyslog.service.d
+        install -m 0644 ${WORKDIR}/rsyslog-override.conf \
+                        ${D}${systemd_system_unitdir}/rsyslog.service.d/rsyslog-override.conf
+        install -d ${D}${bindir}
+        install -m 0755 ${WORKDIR}/rotate-event-logs.sh ${D}/${bindir}/rotate-event-logs.sh
+        rm ${D}${sysconfdir}/rsyslog.d/imjournal.conf
+}
+
+SYSTEMD_SERVICE:${PN}:append:p10bmc = " rotate-event-logs.service"


### PR DESCRIPTION
This is part of the HMC-BMC FFDC enhancement
Use rsyslog configuration to extract Redfish event logs
from the journal and persist them to flash in a text file
named /var/log/redfish

bmcweb sends logs to this file /var/log/redfish while generating redfish events
This audit log will contain all events happened on the system.

Tested by:
power on/off
VMI config

On occuranace of events event data stored in /var/log/redfish file
id: 1
data: {"@odata.type":"#Event.v1_4_0.Event","Events":[{"Context":"","EventId":"1591812688","EventTimestamp":"2020-06-10T18:11:28+00:00","EventType":"Event","Message":"Chassis state has changed to %s.","MessageArgs":["1"],"MessageId":"Base.1.3.ChassisStateChanged","Severity":"OK"}],"Id":"1","Name":"Event Log"}