### PR TITLE
mowgli:mihawk: add phosphor-software-manager-sync

### DIFF
--- a/meta-ibm/meta-witherspoon/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/packagegroups/packagegroup-obmc-apps.bbappend
@@ -7,3 +7,5 @@ RDEPENDS_${PN}-extras_append_mihawk = " phosphor-webui phosphor-image-signing wi
 RDEPENDS_${PN}-extras_append_mowgli = " phosphor-webui phosphor-image-signing phosphor-misc usb-network witherspoon-pfault-analysis"
 
 ${PN}-software-extras_append_ibm-ac-server = " phosphor-software-manager-sync"
+${PN}-software-extras_append_mihawk = " phosphor-software-manager-sync"
+${PN}-software-extras_append_mowgli = " phosphor-software-manager-sync"


### PR DESCRIPTION
The PACKAGECONFIG option is passed to build this feature for both
systems but to install it, need to add the package

This feature copies certain files over to the alternate flash filesystem
so that in situations where a fail over occurs, things like the network
configuration will still work.

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>