### PR TITLE
libmctp: correct failed merge

### DIFF
--- a/meta-phosphor/recipes-phosphor/libmctp/libmctp_git.bb
+++ b/meta-phosphor/recipes-phosphor/libmctp/libmctp_git.bb
@@ -30,12 +30,6 @@ PACKAGECONFIG[astlpc-raw-kcs] = "--enable-astlpc-raw-kcs,--disable-astlpc-raw-kc
 
 CONFFILES:${PN} = "${sysconfdir}/default/mctp"
 
-PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'systemd', d)}"
-PACKAGECONFIG[systemd] = "--with-systemdsystemunitdir=${systemd_system_unitdir}, \
-                          --without-systemdsystemunitdir,systemd"
-
-CONFFILES:${PN} = "${sysconfdir}/default/mctp"
-
 do_install:append() {
 	install -d ${D}${sysconfdir}/default
 	install -m 0644 ${WORKDIR}/mctp ${D}${sysconfdir}/default/mctp


### PR DESCRIPTION
The removed lines are de-duplicated.  The duplication caused unexpected
behavior when the first PACKAGECONFIG ??= line was changed and
subsequently overwritten by the second instance of PACKAGECONFIG ??=

Fixes: f3a9347e5844979082de5468b70bc9f548b4227e
Signed-off-by: Brad Bishop <bradleyb@fuzziesquirrel.com>