### PR TITLE
meta-openpower: Updating GUARD file path

### DIFF
--- a/meta-openpower/recipes-phosphor/dump/phosphor-debug-collector/plugins.d/guard
+++ b/meta-openpower/recipes-phosphor/dump/phosphor-debug-collector/plugins.d/guard
@@ -7,7 +7,7 @@
 . $DREPORT_INCLUDE/functions
 
 desc="GUARD Records"
-file_name="/var/lib/phosphor-software-manager/pnor/prsv/GUARD"
+file_name="/var/lib/phosphor-software-manager/hostfw/running/GUARD"
 
 # Check file is present and not empty.
 if [ ! -s "$file_name" ]; then


### PR DESCRIPTION
Change:
-The pnor directories are being replaced with the hostfw directories,
Hence changing the guard file path.

Signed-off-by: Chirag Sharma <chirshar@in.ibm.com>