### PR TITLE
fix up github SRC_URIs

### DIFF
--- a/meta-aspeed/recipes-kernel/linux/linux-aspeed.inc
+++ b/meta-aspeed/recipes-kernel/linux/linux-aspeed.inc
@@ -6,7 +6,7 @@ PROVIDES += "virtual/kernel"
 
 KCONFIG_MODE="--alldefconfig"
 
-KSRC ?= "git://github.com/openbmc/linux;protocol=git;branch=${KBRANCH}"
+KSRC ?= "git://github.com/openbmc/linux;protocol=https;branch=${KBRANCH}"
 SRC_URI = "${KSRC}"
 SRC_URI += " file://defconfig"
 

--- a/meta-ibm/meta-fsp2/recipes-bsp/u-boot/u-boot-fsp2_git.bb
+++ b/meta-ibm/meta-fsp2/recipes-bsp/u-boot/u-boot-fsp2_git.bb
@@ -1,6 +1,6 @@
 require recipes-bsp/u-boot/u-boot.inc
 
-SRC_URI = "git://github.com/openbmc/u-boot;branch=v2017.11-fsp2-openbmc"
+SRC_URI = "git://github.com/openbmc/u-boot;branch=v2017.11-fsp2-openbmc;protocol=https"
 SRCREV = "d675f0a16ecc876b1aa78b4151af89c80fe0f4b9"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://Licenses/gpl-2.0.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"

--- a/meta-ibm/meta-fsp2/recipes-kernel/linux/linux-fsp2.inc
+++ b/meta-ibm/meta-fsp2/recipes-kernel/linux/linux-fsp2.inc
@@ -4,7 +4,7 @@ LICENSE = "GPLv2"
 
 KCONFIG_MODE="--alldefconfig"
 
-KSRC ?= "git://github.com/openbmc/linux;protocol=git;branch=dev-4.17"
+KSRC ?= "git://github.com/openbmc/linux;protocol=https;branch=dev-4.17"
 SRC_URI = "${KSRC}"
 
 LINUX_VERSION_EXTENSION ?= "-${SRCREV}"

--- a/meta-ibm/meta-palmetto/conf/machine/palmetto.conf
+++ b/meta-ibm/meta-palmetto/conf/machine/palmetto.conf
@@ -14,7 +14,7 @@ FLASH_SIZE = "32768"
 
 PHOSPHOR_MRW_LICENSE = "Apache-2.0"
 PHOSPHOR_MRW_LIC_FILES_CHKSUM = "file://LICENSE;md5=d2794c0df5b907fdace235a619d80314"
-PHOSPHOR_MRW_URI = "git://github.com/open-power/palmetto-xml"
+PHOSPHOR_MRW_URI = "git://github.com/open-power/palmetto-xml;branch=master;protocol=https"
 PHOSPHOR_MRW_REV = "82818682f2c2009c30d700df6d5f8897a3096e4f"
 
 PREFERRED_PROVIDER_virtual/phosphor-led-manager-config-native = "palmetto-led-manager-config-native"

--- a/meta-ibm/meta-romulus/conf/machine/romulus.conf
+++ b/meta-ibm/meta-romulus/conf/machine/romulus.conf
@@ -11,7 +11,7 @@ require conf/machine/include/p9.inc
 
 PHOSPHOR_MRW_LICENSE = "Apache-2.0"
 PHOSPHOR_MRW_LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-PHOSPHOR_MRW_URI = "git://github.com/open-power/romulus-xml"
+PHOSPHOR_MRW_URI = "git://github.com/open-power/romulus-xml;branch=master;protocol=https"
 PHOSPHOR_MRW_REV = "14b471fbf37f5fb60261de001df83caf5f96d81f"
 
 PREFERRED_PROVIDER_virtual/openpower-occ-control-config-native = "romulus-occ-control-config-native"

--- a/meta-ibm/meta-witherspoon/conf/machine/mihawk.conf
+++ b/meta-ibm/meta-witherspoon/conf/machine/mihawk.conf
@@ -17,7 +17,7 @@ require conf/distro/include/phosphor-aspeednic-use-mac2.inc
 
 PHOSPHOR_MRW_LICENSE = "Apache-2.0"
 PHOSPHOR_MRW_LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
-PHOSPHOR_MRW_URI = "git://github.com/open-power/mihawk-xml"
+PHOSPHOR_MRW_URI = "git://github.com/open-power/mihawk-xml;branch=master;protocol=https"
 PHOSPHOR_MRW_REV = "f6ec5aa0f9803d44b147a7670dec7ec935f59582"
 
 

--- a/meta-ibm/meta-witherspoon/conf/machine/mowgli.conf
+++ b/meta-ibm/meta-witherspoon/conf/machine/mowgli.conf
@@ -19,7 +19,7 @@ require conf/distro/include/phosphor-aspeednic-use-mac2.inc
 
 PHOSPHOR_MRW_LICENSE = "Apache-2.0"
 PHOSPHOR_MRW_LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-PHOSPHOR_MRW_URI = "git://github.com/open-power/mowgli-xml"
+PHOSPHOR_MRW_URI = "git://github.com/open-power/mowgli-xml;branch=master;protocol=https"
 PHOSPHOR_MRW_REV = "59f387892e37b5eef5b97b4d0634a62eb63f76b7"
 
 

--- a/meta-ibm/meta-witherspoon/conf/machine/swift.conf
+++ b/meta-ibm/meta-witherspoon/conf/machine/swift.conf
@@ -6,7 +6,7 @@ KERNEL_DEVICETREE = "${KMACHINE}-bmc-opp-${MACHINE}.dtb"
 
 PHOSPHOR_MRW_LICENSE = "Apache-2.0"
 PHOSPHOR_MRW_LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-PHOSPHOR_MRW_URI = "git://git@github.com/open-power/swift-xml;protocol=ssh"
+PHOSPHOR_MRW_URI = "git://git@github.com/open-power/swift-xml;protocol=ssh;branch=master;protocol=https"
 PHOSPHOR_MRW_REV = "7880e778af3fca75f46aa3e94f7e9971a6ddbb1f"
 
 # 128MB flash size

--- a/meta-ibm/meta-witherspoon/conf/machine/witherspoon.conf
+++ b/meta-ibm/meta-witherspoon/conf/machine/witherspoon.conf
@@ -18,7 +18,7 @@ require conf/machine/include/p9.inc
 
 PHOSPHOR_MRW_LICENSE = "Apache-2.0"
 PHOSPHOR_MRW_LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-PHOSPHOR_MRW_URI = "git://github.com/open-power/witherspoon-xml"
+PHOSPHOR_MRW_URI = "git://github.com/open-power/witherspoon-xml;branch=master;protocol=https"
 PHOSPHOR_MRW_REV = "c622cb5a5dd3ebc2a4eef558d1b70740f914e6f7"
 
 # Inhibit phosphor-hwmon-config-mrw

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/gpu/phosphor-gpu_git.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/gpu/phosphor-gpu_git.bb
@@ -18,7 +18,7 @@ DEPENDS += "nlohmann-json"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-SRC_URI := "git://github.com/wistron-corporation/phosphor-gpu.git;protocol=git"
+SRC_URI := "git://github.com/wistron-corporation/phosphor-gpu.git;protocol=https;branch=master"
 SRCREV := "4488c740659130603636d783d895a5d5f965c806"
 S = "${WORKDIR}/git"
 

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/wistron-ipmi-oem_git.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/ipmi/wistron-ipmi-oem_git.bb
@@ -13,7 +13,7 @@ DEPENDS += "phosphor-ipmi-host"
 DEPENDS += "autoconf-archive-native"
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/openbmc/wistron-ipmi-oem"
+SRC_URI = "git://github.com/openbmc/wistron-ipmi-oem;branch=master;protocol=https"
 SRCREV = "ba89a1ea570cb010c2e929ac11ada3714878ca7d"
 
 FILES_${PN}_append = " ${libdir}/ipmid-providers/lib*${SOLIBS}"

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/misc/phosphor-misc_git.bb
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/misc/phosphor-misc_git.bb
@@ -9,7 +9,7 @@ inherit meson pkgconfig allarch
 
 EXTRA_OEMESON = "-Dusb-ctrl=enabled"
 
-SRC_URI += "git://github.com/openbmc/phosphor-misc"
+SRC_URI += "git://github.com/openbmc/phosphor-misc;branch=master;protocol=https"
 SRCREV = "4285bbf84013b0469b220567d8bfccc73d809cd9"
 
 S = "${WORKDIR}/git"

--- a/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis.inc
+++ b/meta-ibm/meta-witherspoon/recipes-phosphor/power/witherspoon-pfault-analysis.inc
@@ -1,7 +1,7 @@
 HOMEPAGE = "https://github.com/openbmc/witherspoon-pfault-analysis"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-SRC_URI += "git://github.com/ibm-openbmc/witherspoon-pfault-analysis;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/witherspoon-pfault-analysis;branch=OP940;protocol=https"
 SRCREV = "dd8000ec8d2968be0586a5b0a528fd0901c3c669"
 
 DEPENDS += "i2c-tools"

--- a/meta-ibm/recipes-phosphor/dbus/ibm-dbus-interfaces_git.bb
+++ b/meta-ibm/recipes-phosphor/dbus/ibm-dbus-interfaces_git.bb
@@ -14,7 +14,7 @@ inherit phosphor-dbus-yaml
 DEPENDS += "autoconf-archive-native"
 DEPENDS += "sdbus++-native"
 
-SRC_URI += "git://github.com/openbmc/ibm-dbus-interfaces"
+SRC_URI += "git://github.com/openbmc/ibm-dbus-interfaces;branch=master;protocol=https"
 SRCREV = "109271bb4de159b9cf13c56acded3eb79bff61fb"
 
 DEPENDS_remove_class-native = "sdbus++-native"

--- a/meta-ibm/recipes-phosphor/logging/ibm-logging_git.bb
+++ b/meta-ibm/recipes-phosphor/logging/ibm-logging_git.bb
@@ -5,7 +5,7 @@ PV = "1.0+git${SRCPV}"
 HOMEPAGE = "https://github.com/openbmc/ibm-logging"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
-SRC_URI += "git://github.com/openbmc/ibm-logging"
+SRC_URI += "git://github.com/openbmc/ibm-logging;branch=master;protocol=https"
 SRCREV = "3dd7c2e6deec6b4fe3e46b240eae53848dcc520a"
 
 inherit autotools

--- a/meta-openpower/recipes-bsp/ecmd/croserver_git.bb
+++ b/meta-openpower/recipes-bsp/ecmd/croserver_git.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "eCMD is a hardware access API for IBM Systems"
 LICENSE= "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${S}/NOTICE;md5=fee220301a2af3faf8f211524b4248ea"
 
-SRC_URI = "git://github.com/open-power/eCMD.git"
+SRC_URI = "git://github.com/open-power/eCMD.git;branch=master;protocol=https"
 SRCREV = "46282c03e686dfed51173e04eba06b96b2552401"
 DEPENDS += "python-native zlib"
 

--- a/meta-openpower/recipes-bsp/ffs/ffs_git.bb
+++ b/meta-openpower/recipes-bsp/ffs/ffs_git.bb
@@ -3,6 +3,6 @@ require ffs.inc
 PV = "v0.1.0+git${SRCPV}"
 
 SRCREV = "3ec70fbc458e32eef0d0b1de79688b4dc48cbd57"
-SRC_URI += "git://github.com/open-power/ffs.git"
+SRC_URI += "git://github.com/open-power/ffs.git;branch=master;protocol=https"
 
 S = "${WORKDIR}/git"

--- a/meta-openpower/recipes-bsp/fsidbg/fsidbg_git.bb
+++ b/meta-openpower/recipes-bsp/fsidbg/fsidbg_git.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "fsidbg is a tool to access remote FSI engines and perform client 
 LICENSE     = "GPLv3"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-SRC_URI += "git://github.com/eddiejames/fsidbg.git"
+SRC_URI += "git://github.com/eddiejames/fsidbg.git;branch=master;protocol=https"
 
 SRCREV = "dfe278065c877724242dfae15a4c627fd2e3611c"
 PV = "git${SRCREV}"

--- a/meta-openpower/recipes-bsp/pdbg/pdbg_3.1.bb
+++ b/meta-openpower/recipes-bsp/pdbg/pdbg_3.1.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 PV = "3.1+git${SRCPV}"
 
-SRC_URI += "git://github.com/open-power/pdbg.git"
+SRC_URI += "git://github.com/open-power/pdbg.git;branch=master;protocol=https"
 SRCREV = "v3.1"
 
 DEPENDS += "dtc-native"

--- a/meta-openpower/recipes-bsp/skiboot/skiboot.inc
+++ b/meta-openpower/recipes-bsp/skiboot/skiboot.inc
@@ -1,7 +1,7 @@
 HOMEPAGE = "https://github.com/open-power"
 LICENSE = "Apache-2.0"
 
-SRC_URI += "git://github.com/open-power/skiboot.git"
+SRC_URI += "git://github.com/open-power/skiboot.git;branch=master;protocol=https"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/skiboot:"
 

--- a/meta-openpower/recipes-phosphor/dbus/openpower-dbus-interfaces_git.bb
+++ b/meta-openpower/recipes-phosphor/dbus/openpower-dbus-interfaces_git.bb
@@ -14,7 +14,7 @@ inherit phosphor-dbus-yaml
 DEPENDS += "autoconf-archive-native"
 DEPENDS += "sdbus++-native"
 
-SRC_URI += "git://github.com/ibm-openbmc/openpower-dbus-interfaces;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/openpower-dbus-interfaces;branch=OP940;protocol=https"
 SRCREV = "c6d7984fa6d4d1bf51fd2bb91eb44d630f891f87"
 
 DEPENDS_remove_class-native = "sdbus++-native"

--- a/meta-openpower/recipes-phosphor/debug/openpower-debug-collector.inc
+++ b/meta-openpower/recipes-phosphor/debug/openpower-debug-collector.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "https://github.com/openbmc/openpower-debug-collector"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-SRC_URI += "git://github.com/openbmc/openpower-debug-collector"
+SRC_URI += "git://github.com/openbmc/openpower-debug-collector;branch=master;protocol=https"
 SRCREV = "b618ccbaa758fcc282669b2b5c90c50df1725a10"

--- a/meta-openpower/recipes-phosphor/flash/openpower-software-manager_git.bb
+++ b/meta-openpower/recipes-phosphor/flash/openpower-software-manager_git.bb
@@ -37,7 +37,7 @@ RDEPENDS_${PN} += " \
 
 S = "${WORKDIR}/git"
 
-SRC_URI += "git://github.com/ibm-openbmc/openpower-pnor-code-mgmt;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/openpower-pnor-code-mgmt;branch=OP940;protocol=https"
 SRCREV = "33595b324e049bb4f7bf83aeefc6306ea6a8a8a9"
 
 DBUS_SERVICE_${PN} += "org.open_power.Software.Host.Updater.service"

--- a/meta-openpower/recipes-phosphor/host/aspeed-lpc-ctrl_git.bb
+++ b/meta-openpower/recipes-phosphor/host/aspeed-lpc-ctrl_git.bb
@@ -13,5 +13,5 @@ S = "${WORKDIR}/git"
 
 SYSTEMD_SERVICE_${PN} += "pnorboot.service"
 
-SRC_URI += "git://github.com/shenki/aspeed-lpc-control"
+SRC_URI += "git://github.com/shenki/aspeed-lpc-control;branch=master;protocol=https"
 SRCREV = "af42b7ff01e71c0dd4c60214dd46ed487611f36d"

--- a/meta-openpower/recipes-phosphor/host/op-proc-control_git.bb
+++ b/meta-openpower/recipes-phosphor/host/op-proc-control_git.bb
@@ -10,7 +10,7 @@ S = "${WORKDIR}/git"
 inherit autotools obmc-phosphor-utils pkgconfig pythonnative
 inherit systemd
 
-SRC_URI += "git://github.com/ibm-openbmc/openpower-proc-control;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/openpower-proc-control;branch=OP940;protocol=https"
 SRCREV = "bfa88ed112efdabd6b9589da0100ee9e9c0d716e"
 
 DEPENDS += " \

--- a/meta-openpower/recipes-phosphor/ipmi/openpower-host-ipmi-flash_git.bb
+++ b/meta-openpower/recipes-phosphor/ipmi/openpower-host-ipmi-flash_git.bb
@@ -21,7 +21,7 @@ HOSTIPMI_PROVIDER_LIBRARY += "libhiomap.so"
 
 S = "${WORKDIR}/git"
 
-SRC_URI += "git://github.com/openbmc/openpower-host-ipmi-flash"
+SRC_URI += "git://github.com/openbmc/openpower-host-ipmi-flash;branch=master;protocol=https"
 SRCREV = "d4b7f5e4819aa6e3ddb165a80149dd1a1c1649d7"
 
 FILES_${PN}_append = " ${libdir}/ipmid-providers/lib*${SOLIBS}"

--- a/meta-openpower/recipes-phosphor/ipmi/openpower-ipmi-oem.inc
+++ b/meta-openpower/recipes-phosphor/ipmi/openpower-ipmi-oem.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "https://github.com/openbmc/openpower-host-ipmi-oem"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fa818a259cbed7ce8bc2a22d35a464fc"
-SRC_URI += "git://github.com/openbmc/openpower-host-ipmi-oem"
+SRC_URI += "git://github.com/openbmc/openpower-host-ipmi-oem;branch=master;protocol=https"
 SRCREV = "64354b6604e6a1d6b60463cae15c33b137768e1b"

--- a/meta-openpower/recipes-phosphor/occ/openpower-occ-control.inc
+++ b/meta-openpower/recipes-phosphor/occ/openpower-occ-control.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "https://github.com/openbmc/openpower-occ-control"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-SRC_URI += "git://github.com/ibm-openbmc/openpower-occ-control;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/openpower-occ-control;branch=OP940;protocol=https"
 SRCREV = "b4149165783bf7f3ca330cdbacc9db8b32d5d054"

--- a/meta-openpower/recipes-phosphor/vpd/openpower-fru-vpd.inc
+++ b/meta-openpower/recipes-phosphor/vpd/openpower-fru-vpd.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "https://github.com/openbmc/openpower-vpd-parser"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-SRC_URI += "git://github.com/ibm-openbmc/openpower-vpd-parser;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/openpower-vpd-parser;branch=OP940;protocol=https"
 SRCREV = "c8da64ddca44ce8601ee2147dee45913a7e1300b"

--- a/meta-phosphor/aspeed-layer/recipes-kernel/cf-fsi-firmware/cf-fsi-firmware_git.bb
+++ b/meta-phosphor/aspeed-layer/recipes-kernel/cf-fsi-firmware/cf-fsi-firmware_git.bb
@@ -5,7 +5,7 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 SRCREV = "bae32e353a3641b5164211f6bf06c5620f6e384d"
-SRC_URI = "git://github.com/ozbenh/cf-fsi.git"
+SRC_URI = "git://github.com/ozbenh/cf-fsi.git;branch=master;protocol=https"
 
 PR = "r1"
 PV = "1.0+git${SRCPV}"

--- a/meta-phosphor/classes/mrw-rev.bbclass
+++ b/meta-phosphor/classes/mrw-rev.bbclass
@@ -1,5 +1,5 @@
-MRW_API_SRC_URI ?= "git://github.com/open-power/serverwiz.git"
+MRW_API_SRC_URI ?= "git://github.com/open-power/serverwiz.git;branch=master;protocol=https"
 MRW_API_SRCREV ?= "60c8e10cbb11768cd1ba394b35cb1d6627efec42"
 
-MRW_TOOLS_SRC_URI ?= "git://github.com/openbmc/phosphor-mrw-tools"
+MRW_TOOLS_SRC_URI ?= "git://github.com/openbmc/phosphor-mrw-tools;branch=master;protocol=https"
 MRW_TOOLS_SRCREV ?= "3d7698c2be703ffbc78bb6cbb66186fbc6f06d37"

--- a/meta-phosphor/classes/phosphor-networkd-rev.bbclass
+++ b/meta-phosphor/classes/phosphor-networkd-rev.bbclass
@@ -1,2 +1,2 @@
-SRC_URI += "git://github.com/ibm-openbmc/phosphor-networkd;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/phosphor-networkd;branch=OP940;protocol=https"
 SRCREV = "058d372c8095ba2fd7f592a91d9c1f0cd3070701"

--- a/meta-phosphor/classes/skeleton-rev.bbclass
+++ b/meta-phosphor/classes/skeleton-rev.bbclass
@@ -1,4 +1,4 @@
 SRCREV ?= "c8334f3258cb80839e49defe386d33c196929215"
-SKELETON_URI ?= "git://github.com/openbmc/skeleton"
+SKELETON_URI ?= "git://github.com/openbmc/skeleton;branch=master;protocol=https"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"

--- a/meta-phosphor/recipes-connectivity/jsnbd/jsnbd_git.bb
+++ b/meta-phosphor/recipes-connectivity/jsnbd/jsnbd_git.bb
@@ -14,7 +14,7 @@ RDEPENDS_${PN} += "nbd-client"
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/openbmc/jsnbd"
+SRC_URI = "git://github.com/openbmc/jsnbd;branch=master;protocol=https"
 SRCREV = "bcc6cc5bcadb20005ae03c8c4a4eb87006f0d222"
 
 NBD_PROXY_CONFIG_JSON ??= "${S}/config.sample.json"

--- a/meta-phosphor/recipes-devtools/iotools/iotools_1.6.bb
+++ b/meta-phosphor/recipes-devtools/iotools/iotools_1.6.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/jonmayergoogle/iotools"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 SRCREV = "8d928b3360246b8ead95b442ca3887ce8b8f942f"
-SRC_URI = "git://git@github.com/jonmayergoogle/iotools.git;protocol=https"
+SRC_URI = "git://git@github.com/jonmayergoogle/iotools.git;protocol=https;branch=master"
 PV = "v1.6+git${SRCPV}"
 
 inherit obmc-phosphor-systemd

--- a/meta-phosphor/recipes-devtools/python/pyphosphor_git.bb
+++ b/meta-phosphor/recipes-devtools/python/pyphosphor_git.bb
@@ -48,7 +48,7 @@ FILES_${PN}-wsgi-apps-ns = "${PYTHON_SITEPACKAGES_DIR}/obmc/wsgi/apps/__init__.p
 FILES_${PN}-utils = "${PYTHON_SITEPACKAGES_DIR}/obmc/utils"
 FILES_${PN}-dbus = "${PYTHON_SITEPACKAGES_DIR}/obmc/dbuslib"
 
-SRC_URI += "git://github.com/openbmc/pyphosphor"
+SRC_URI += "git://github.com/openbmc/pyphosphor;branch=master;protocol=https"
 
 SRCREV = "d2aadf1220b03580ab5f93fd15e068040cdb895b"
 

--- a/meta-phosphor/recipes-extended/gpioplus/gpioplus_git.bb
+++ b/meta-phosphor/recipes-extended/gpioplus/gpioplus_git.bb
@@ -13,7 +13,7 @@ EXTRA_OEMESON = " \
         -Dtests=disabled \
         "
 
-SRC_URI += "git://github.com/openbmc/gpioplus"
+SRC_URI += "git://github.com/openbmc/gpioplus;branch=master;protocol=https"
 SRCREV = "48e6288da8486a25fd52e944fb0f7148fc1c02db"
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/recipes-extended/pam/pam-ipmi_git.bb
+++ b/meta-phosphor/recipes-extended/pam/pam-ipmi_git.bb
@@ -7,7 +7,7 @@ PV = "1.0+git${SRCPV}"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-SRC_URI += "git://github.com/openbmc/pam-ipmi"
+SRC_URI += "git://github.com/openbmc/pam-ipmi;branch=master;protocol=https"
 SRCREV = "65edb939ef8ffc4d46c7d12e759580c048c5d348"
 S = "${WORKDIR}/git"
 

--- a/meta-phosphor/recipes-extended/sdbusplus/sdbusplus_git.bb
+++ b/meta-phosphor/recipes-extended/sdbusplus/sdbusplus_git.bb
@@ -36,7 +36,7 @@ DEPENDS_append_class-native = " \
         python-pyyaml-native \
         "
 
-SRC_URI += "git://github.com/openbmc/sdbusplus"
+SRC_URI += "git://github.com/openbmc/sdbusplus;branch=master;protocol=https"
 SRCREV = "f8bbf17c3db879359b0984b40250e4db3d274be1"
 
 PACKAGECONFIG ??= "libsdbusplus transaction"

--- a/meta-phosphor/recipes-extended/sdeventplus/sdeventplus_git.bb
+++ b/meta-phosphor/recipes-extended/sdeventplus/sdeventplus_git.bb
@@ -19,7 +19,7 @@ EXTRA_OEMESON = " \
         -Dtests=disabled \
         "
 
-SRC_URI += "git://github.com/openbmc/sdeventplus"
+SRC_URI += "git://github.com/openbmc/sdeventplus;branch=master;protocol=https"
 SRCREV = "b315a2ab41ab6408a2185162fdd56c836249abdc"
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/recipes-extended/stdplus/stdplus_git.bb
+++ b/meta-phosphor/recipes-extended/stdplus/stdplus_git.bb
@@ -13,7 +13,7 @@ EXTRA_OEMESON = " \
         -Dtests=disabled \
         "
 
-SRC_URI += "git://github.com/openbmc/stdplus"
+SRC_URI += "git://github.com/openbmc/stdplus;branch=master;protocol=https"
 SRCREV = "7d75a48513560d8735bb3d795bb8872af276ee43"
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/recipes-graphics/obmc-ikvm/obmc-ikvm_git.bb
+++ b/meta-phosphor/recipes-graphics/obmc-ikvm/obmc-ikvm_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=75859989545e37968a99b631ef42722e"
 
 DEPENDS = " libvncserver systemd sdbusplus phosphor-logging phosphor-dbus-interfaces"
 
-SRC_URI = "git://github.com/openbmc/obmc-ikvm"
+SRC_URI = "git://github.com/openbmc/obmc-ikvm;branch=master;protocol=https"
 SRCREV = "7cf1f1d43ef9b4c312bfb2c7c61514ca93a53ee6"
 
 PV = "1.0+git${SRCPV}"

--- a/meta-phosphor/recipes-phosphor/certificate/phosphor-certificate-manager_git.bb
+++ b/meta-phosphor/recipes-phosphor/certificate/phosphor-certificate-manager_git.bb
@@ -8,7 +8,7 @@ PV = "0.1+git${SRCPV}"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-SRC_URI = "git://github.com/ibm-openbmc/phosphor-certificate-manager;branch=OP940"
+SRC_URI = "git://github.com/ibm-openbmc/phosphor-certificate-manager;branch=OP940;protocol=https"
 SRCREV = "e41fed35e55c623ac746e2f3113331215a364537"
 
 inherit autotools \

--- a/meta-phosphor/recipes-phosphor/chassis/obmc-phosphor-buttons_git.bb
+++ b/meta-phosphor/recipes-phosphor/chassis/obmc-phosphor-buttons_git.bb
@@ -6,7 +6,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 S = "${WORKDIR}/git"
-SRC_URI += "git://github.com/openbmc/phosphor-buttons.git"
+SRC_URI += "git://github.com/openbmc/phosphor-buttons.git;branch=master;protocol=https"
 SRCREV = "1ac9ab6d29dc06bf15f1377fc8aebb21a3e5a600"
 
 inherit cmake pkgconfig systemd

--- a/meta-phosphor/recipes-phosphor/chassis/obmc-phosphor-power_git.bb
+++ b/meta-phosphor/recipes-phosphor/chassis/obmc-phosphor-power_git.bb
@@ -14,5 +14,5 @@ DEPENDS += "gpioplus"
 
 S = "${WORKDIR}/git"
 
-SRC_URI = "git://github.com/openbmc/phosphor-power-control"
+SRC_URI = "git://github.com/openbmc/phosphor-power-control;branch=master;protocol=https"
 SRCREV = "4d209a24588d112dfd61158b2e01dd973d99961e"

--- a/meta-phosphor/recipes-phosphor/configuration/entity-manager_git.bb
+++ b/meta-phosphor/recipes-phosphor/configuration/entity-manager_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "Entity Manager"
 DESCRIPTION = "Entity Manager provides d-bus configuration data \
 and configures system sensors"
 
-SRC_URI = "git://github.com/openbmc/entity-manager.git"
+SRC_URI = "git://github.com/openbmc/entity-manager.git;branch=master;protocol=https"
 SRCREV = "f861da89ed03f9ec556c5ed6ac819988c0c1f498"
 PV = "0.1+git${SRCPV}"
 

--- a/meta-phosphor/recipes-phosphor/console/obmc-console_git.bb
+++ b/meta-phosphor/recipes-phosphor/console/obmc-console_git.bb
@@ -15,7 +15,7 @@ DEPENDS += "autoconf-archive-native \
             systemd \
             "
 
-SRC_URI += "git://github.com/openbmc/obmc-console"
+SRC_URI += "git://github.com/openbmc/obmc-console;branch=master;protocol=https"
 SRC_URI += "file://${BPN}.conf"
 
 SRCREV = "1cecc5deeae236e9886f624ea7168e075f057047"

--- a/meta-phosphor/recipes-phosphor/datetime/phosphor-time-manager_git.bb
+++ b/meta-phosphor/recipes-phosphor/datetime/phosphor-time-manager_git.bb
@@ -19,7 +19,7 @@ RDEPENDS_${PN} += "${VIRTUAL-RUNTIME_obmc-settings-mgmt}"
 RDEPENDS_${PN} += "phosphor-network"
 RDEPENDS_${PN} += "phosphor-mapper"
 
-SRC_URI += "git://github.com/openbmc/phosphor-time-manager"
+SRC_URI += "git://github.com/openbmc/phosphor-time-manager;branch=master;protocol=https"
 SRCREV = "66bc0a5a9fed4c06c4b26bd35e00351f2d603f4e"
 PV = "1.0+git${SRCPV}"
 S = "${WORKDIR}/git"

--- a/meta-phosphor/recipes-phosphor/dbus/phosphor-dbus-interfaces_git.bb
+++ b/meta-phosphor/recipes-phosphor/dbus/phosphor-dbus-interfaces_git.bb
@@ -13,7 +13,7 @@ inherit phosphor-dbus-yaml
 DEPENDS += "autoconf-archive-native"
 DEPENDS += "sdbus++-native"
 
-SRC_URI += "git://github.com/ibm-openbmc/phosphor-dbus-interfaces;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/phosphor-dbus-interfaces;branch=OP940;protocol=https"
 SRCREV = "c031c236bbc5174b2df15be60237ff1db9e5ba1f"
 
 DEPENDS_remove_class-native = "sdbus++-native"

--- a/meta-phosphor/recipes-phosphor/dbus/phosphor-dbus-monitor_git.bb
+++ b/meta-phosphor/recipes-phosphor/dbus/phosphor-dbus-monitor_git.bb
@@ -6,7 +6,7 @@ PV = "1.0+git${SRCPV}"
 HOMEPAGE = "http://github.com/openbmc/phosphor-dbus-monitor"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-SRC_URI = "git://github.com/openbmc/phosphor-dbus-monitor"
+SRC_URI = "git://github.com/openbmc/phosphor-dbus-monitor;branch=master;protocol=https"
 SRCREV = "92907da08e311656bd5980476c252c19e8dbad11"
 
 inherit autotools \

--- a/meta-phosphor/recipes-phosphor/dbus/phosphor-mapper_git.bb
+++ b/meta-phosphor/recipes-phosphor/dbus/phosphor-mapper_git.bb
@@ -24,7 +24,7 @@ SYSTEMD_SERVICE_${PN} += " \
         mapper-wait@.service \
         mapper-subtree-remove@.service \
         "
-SRC_URI += "git://github.com/openbmc/phosphor-objmgr"
+SRC_URI += "git://github.com/openbmc/phosphor-objmgr;branch=master;protocol=https"
 
 SRCREV = "5eddf44006cf9ad5b9a5c103adc1682fc835f932"
 

--- a/meta-phosphor/recipes-phosphor/dump/phosphor-debug-collector.inc
+++ b/meta-phosphor/recipes-phosphor/dump/phosphor-debug-collector.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "https://github.com/openbmc/phosphor-debug-collector"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-SRC_URI += "git://github.com/openbmc/phosphor-debug-collector"
+SRC_URI += "git://github.com/openbmc/phosphor-debug-collector;branch=master;protocol=https"
 SRCREV = "004938eb17af464fc1ba02f883adb78ad3bd40dd"

--- a/meta-phosphor/recipes-phosphor/fans/phosphor-fan.inc
+++ b/meta-phosphor/recipes-phosphor/fans/phosphor-fan.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "https://github.com/openbmc/phosphor-fan-presence"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-SRC_URI += "git://github.com/ibm-openbmc/phosphor-fan-presence;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/phosphor-fan-presence;branch=OP940;protocol=https"
 SRCREV = "6a805a63291b9284e516e03b004277e45524fa80"

--- a/meta-phosphor/recipes-phosphor/fans/phosphor-pid-control_git.bb
+++ b/meta-phosphor/recipes-phosphor/fans/phosphor-pid-control_git.bb
@@ -13,7 +13,7 @@ inherit obmc-phosphor-ipmiprovider-symlink
 inherit systemd
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/openbmc/phosphor-pid-control"
+SRC_URI = "git://github.com/openbmc/phosphor-pid-control;branch=master;protocol=https"
 SRCREV = "e7f4a5d5c93b8ee7e91351c6f7c3e66f03cb40f5"
 
 # Each platform will need a service file that starts

--- a/meta-phosphor/recipes-phosphor/flash/phosphor-software-manager.inc
+++ b/meta-phosphor/recipes-phosphor/flash/phosphor-software-manager.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "https://github.com/openbmc/phosphor-bmc-code-mgmt"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-SRC_URI += "git://github.com/openbmc/phosphor-bmc-code-mgmt"
+SRC_URI += "git://github.com/openbmc/phosphor-bmc-code-mgmt;branch=master;protocol=https"
 SRCREV = "a013560f96a9ee5c2db4e1778c7dcee199c3acf1"

--- a/meta-phosphor/recipes-phosphor/gpio/phosphor-gpio-monitor_git.bb
+++ b/meta-phosphor/recipes-phosphor/gpio/phosphor-gpio-monitor_git.bb
@@ -37,6 +37,6 @@ FILES_${PN}-monitor += "${bindir}/phosphor-gpio-monitor"
 FILES_${PN}-monitor += "${bindir}/phosphor-gpio-util"
 FILES_${PN}-presence += "${bindir}/phosphor-gpio-presence"
 
-SRC_URI += "git://github.com/openbmc/phosphor-gpio-monitor"
+SRC_URI += "git://github.com/openbmc/phosphor-gpio-monitor;branch=master;protocol=https"
 SRCREV = "206f0040985e27a0651a9164d7958bf347142a31"
 S = "${WORKDIR}/git"

--- a/meta-phosphor/recipes-phosphor/host/phosphor-host-postd_git.bb
+++ b/meta-phosphor/recipes-phosphor/host/phosphor-host-postd_git.bb
@@ -16,7 +16,7 @@ DEPENDS += "phosphor-dbus-interfaces"
 DEPENDS += "systemd"
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/openbmc/phosphor-host-postd"
+SRC_URI = "git://github.com/openbmc/phosphor-host-postd;branch=master;protocol=https"
 SRCREV = "49a18b220229304b690097041d8028895bd4215a"
 
 SNOOP_DEVICE ?= "aspeed-lpc-snoop0"

--- a/meta-phosphor/recipes-phosphor/interfaces/bmcweb_git.bb
+++ b/meta-phosphor/recipes-phosphor/interfaces/bmcweb_git.bb
@@ -12,7 +12,7 @@ GROUPMEMS_PARAM_${PN} = "-g web -a root; -g redfish -a root"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENCE;md5=a6a4edad4aed50f39a66d098d74b265b"
 
-SRC_URI = "git://github.com/ibm-openbmc/bmcweb.git;branch=OP940"
+SRC_URI = "git://github.com/ibm-openbmc/bmcweb.git;branch=OP940;protocol=https"
 
 PV = "1.0+git${SRCPV}"
 SRCREV = "d14a2ecfb4b79875d4b572f03d533a4f17c20057"

--- a/meta-phosphor/recipes-phosphor/interfaces/rest-dbus_git.bb
+++ b/meta-phosphor/recipes-phosphor/interfaces/rest-dbus_git.bb
@@ -20,7 +20,7 @@ RDEPENDS_${PN} += " \
 
 SYSTEMD_SERVICE_${PN} += "rest-dbus.service rest-dbus.socket"
 
-SRC_URI += "git://github.com/openbmc/rest-dbus.git"
+SRC_URI += "git://github.com/openbmc/rest-dbus.git;branch=master;protocol=https"
 
 SRCREV = "9273a302e8f2b3c3e939dff77758e90f163bf6a1"
 

--- a/meta-phosphor/recipes-phosphor/interfaces/slpd-lite_git.bb
+++ b/meta-phosphor/recipes-phosphor/interfaces/slpd-lite_git.bb
@@ -14,7 +14,7 @@ SYSTEMD_SERVICE_${PN} += "slpd-lite.service"
 DEPENDS += "systemd"
 DEPENDS += "autoconf-archive-native"
 
-SRC_URI += "git://github.com/openbmc/slpd-lite"
+SRC_URI += "git://github.com/openbmc/slpd-lite;branch=master;protocol=https"
 
 SRCREV = "a592888328e79f0ba61a7099fcb1143bc20a0d43"
 

--- a/meta-phosphor/recipes-phosphor/inventory/phosphor-inventory-manager.inc
+++ b/meta-phosphor/recipes-phosphor/inventory/phosphor-inventory-manager.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "http://github.com/openbmc/phosphor-inventory-manager"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-SRC_URI = "git://github.com/openbmc/phosphor-inventory-manager"
+SRC_URI = "git://github.com/openbmc/phosphor-inventory-manager;branch=master;protocol=https"
 SRCREV = "ded627c42f5e5319e3704fff742a0227c05f00a9"

--- a/meta-phosphor/recipes-phosphor/ipmi/ipmi-blob-tool_git.bb
+++ b/meta-phosphor/recipes-phosphor/ipmi/ipmi-blob-tool_git.bb
@@ -13,5 +13,5 @@ DEPENDS += "autoconf-archive-native"
 EXTRA_OECONF = "--disable-tests"
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/openbmc/ipmi-blob-tool"
+SRC_URI = "git://github.com/openbmc/ipmi-blob-tool;branch=master;protocol=https"
 SRCREV = "958f1ce952849300ebfd30cc04ce86937d3bc718"

--- a/meta-phosphor/recipes-phosphor/ipmi/ipmitool_%.bbappend
+++ b/meta-phosphor/recipes-phosphor/ipmi/ipmitool_%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 DEPENDS += "systemd"
 
-SRC_URI = "git://github.com/ipmitool/ipmitool.git;protocol=https"
+SRC_URI = "git://github.com/ipmitool/ipmitool.git;protocol=https;branch=master"
 SRCREV = "d818c2ff85c011be29c8d3047e516a5e032a1923"
 
 # this patch has been submitted to ipmitool upstream and is in review

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-blobs-binarystore_git.bb
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-blobs-binarystore_git.bb
@@ -16,7 +16,7 @@ DEPENDS += "protobuf-native"
 DEPENDS += "protobuf"
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/openbmc/phosphor-ipmi-blobs-binarystore"
+SRC_URI = "git://github.com/openbmc/phosphor-ipmi-blobs-binarystore;branch=master;protocol=https"
 SRCREV = "e535a736efd8ef2088c57a91c387be7800674161"
 
 FILES_${PN}_append = " ${libdir}/ipmid-providers/lib*${SOLIBS}"

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-blobs_git.bb
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-blobs_git.bb
@@ -15,7 +15,7 @@ DEPENDS += "phosphor-logging"
 DEPENDS += "ipmi-blob-tool"
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/openbmc/phosphor-ipmi-blobs"
+SRC_URI = "git://github.com/openbmc/phosphor-ipmi-blobs;branch=master;protocol=https"
 SRCREV = "8bc117792fbf118dd74d015546c22612961ccc26"
 
 FILES_${PN}_append = " ${libdir}/ipmid-providers/lib*${SOLIBS}"

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-bt_git.bb
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-bt_git.bb
@@ -18,7 +18,7 @@ DEPENDS += "autoconf-archive-native"
 DEPENDS += "systemd"
 
 S = "${WORKDIR}/git"
-SRC_URI += "git://github.com/openbmc/btbridge"
+SRC_URI += "git://github.com/openbmc/btbridge;branch=master;protocol=https"
 SRCREV="aa5511d28ff9acee4a404c6397d09f5187812ed8"
 
 # This is how linux-libc-headers says to include custom uapi headers

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-ethstats_git.bb
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-ethstats_git.bb
@@ -13,7 +13,7 @@ DEPENDS += "autoconf-archive-native"
 DEPENDS += "phosphor-ipmi-host"
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/openbmc/phosphor-ipmi-ethstats"
+SRC_URI = "git://github.com/openbmc/phosphor-ipmi-ethstats;branch=master;protocol=https"
 SRCREV = "7a1b2033e8cce2fe711d8a033885d9048325332d"
 
 FILES_${PN}_append = " ${libdir}/ipmid-providers/lib*${SOLIBS}"

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-flash_git.bb
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-flash_git.bb
@@ -22,7 +22,7 @@ PACKAGECONFIG[cleanup-delete] = "--enable-cleanup-delete, --disable-cleanup-dele
 EXTRA_OECONF = "--disable-tests --disable-build-host-tool"
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/openbmc/phosphor-ipmi-flash"
+SRC_URI = "git://github.com/openbmc/phosphor-ipmi-flash;branch=master;protocol=https"
 SRCREV = "33311b47b3b656cfc16568b4b971730cb79130bc"
 
 FILES_${PN}_append = " ${libdir}/ipmid-providers/lib*${SOLIBS}"

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-fru.inc
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-fru.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "https://github.com/openbmc/ipmi-fru-parser"
 LICENSE = "GPL-3.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7702f203b58979ebbc31bfaeb44f219c"
-SRC_URI += "git://github.com/openbmc/ipmi-fru-parser"
+SRC_URI += "git://github.com/openbmc/ipmi-fru-parser;branch=master;protocol=https"
 SRCREV = "de0a59ee05cfd97cca16654fc21654fc89ab72fa"

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-host.inc
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-host.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "http://github.com/openbmc/phosphor-host-ipmid"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=fa818a259cbed7ce8bc2a22d35a464fc"
-SRC_URI += "git://github.com/ibm-openbmc/phosphor-host-ipmid;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/phosphor-host-ipmid;branch=OP940;protocol=https"
 SRCREV = "b7edc96c773dbcb0706028ef2acacc6d35bcd666"

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-ipmb_git.bb
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-ipmb_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "IPMB bridge"
 DESCRIPTION = "The IPMB bridge implements a Dbus compliant interface for \
 implementing IPMB interfaces"
 
-SRC_URI = "git://github.com/openbmc/ipmbbridge.git"
+SRC_URI = "git://github.com/openbmc/ipmbbridge.git;branch=master;protocol=https"
 SRCREV = "8188d7651c23502f88f9bf850ab7e549f6463997"
 PV = "0.1+git${SRCPV}"
 

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-kcs_git.bb
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-kcs_git.bb
@@ -29,7 +29,7 @@ DEPENDS += " \
         "
 
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/openbmc/kcsbridge.git"
+SRC_URI = "git://github.com/openbmc/kcsbridge.git;branch=master;protocol=https"
 SRCREV = "2cdc49585235a6557c9cbb6c8b75c064fc02681a"
 
 # This is how linux-libc-headers says to include custom uapi headers

--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-net_git.bb
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-net_git.bb
@@ -16,7 +16,7 @@ DEPENDS += "systemd"
 DEPENDS += "phosphor-ipmi-host"
 
 
-SRC_URI += "git://github.com/ibm-openbmc/phosphor-net-ipmid;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/phosphor-net-ipmid;branch=OP940;protocol=https"
 SRC_URI += "file://ipmi-net-firewall.sh"
 SRCREV = "1f722357c223413924355f3a26b1409739373f90"
 

--- a/meta-phosphor/recipes-phosphor/leds/phosphor-led-manager.inc
+++ b/meta-phosphor/recipes-phosphor/leds/phosphor-led-manager.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "http://github.com/openbmc/phosphor-led-manager"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
-SRC_URI += "git://github.com/openbmc/phosphor-led-manager"
+SRC_URI += "git://github.com/openbmc/phosphor-led-manager;branch=master;protocol=https"
 SRCREV = "6fd9e440be73865d99cd408e0f87ec639882267b"

--- a/meta-phosphor/recipes-phosphor/leds/phosphor-led-sysfs_git.bb
+++ b/meta-phosphor/recipes-phosphor/leds/phosphor-led-sysfs_git.bb
@@ -17,7 +17,7 @@ DEPENDS += "boost"
 
 DBUS_SERVICE_${PN} += "xyz.openbmc_project.led.controller@.service"
 
-SRC_URI += "git://github.com/openbmc/phosphor-led-sysfs"
+SRC_URI += "git://github.com/openbmc/phosphor-led-sysfs;branch=master;protocol=https"
 SRC_URI += "file://70-leds.rules"
 SRCREV = "97ddb72359663b5ca9d8e0c22588f0022f729ced"
 S = "${WORKDIR}/git"

--- a/meta-phosphor/recipes-phosphor/logging/ffdc_git.bb
+++ b/meta-phosphor/recipes-phosphor/logging/ffdc_git.bb
@@ -13,7 +13,7 @@ RDEPENDS_${PN} += " \
         "
 
 S = "${WORKDIR}/git"
-SRC_URI += "git://github.com/openbmc/phosphor-debug-collector"
+SRC_URI += "git://github.com/openbmc/phosphor-debug-collector;branch=master;protocol=https"
 
 SRCREV = "5ba7176ca2755080e35daba0b5417386abf17f6d"
 

--- a/meta-phosphor/recipes-phosphor/logging/phosphor-hostlogger_git.bb
+++ b/meta-phosphor/recipes-phosphor/logging/phosphor-hostlogger_git.bb
@@ -36,5 +36,5 @@ EXTRA_OECONF = "HOST_TTY=${OBMC_CONSOLE_HOST_TTY} \
 
 # Source code repository
 S = "${WORKDIR}/git"
-SRC_URI = "git://github.com/openbmc/phosphor-hostlogger"
+SRC_URI = "git://github.com/openbmc/phosphor-hostlogger;branch=master;protocol=https"
 SRCREV = "b8cf26fe933c7f020f5195b9575f596b9cb23719"

--- a/meta-phosphor/recipes-phosphor/logging/phosphor-logging_git.bb
+++ b/meta-phosphor/recipes-phosphor/logging/phosphor-logging_git.bb
@@ -52,7 +52,7 @@ FILES_phosphor-rsyslog-config += " \
         ${bindir}/phosphor-rsyslog-conf \
 "
 
-SRC_URI += "git://github.com/ibm-openbmc/phosphor-logging;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/phosphor-logging;branch=OP940;protocol=https"
 SRCREV = "579407e93fb85dc9630470e4b7349681d928d0c3"
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/recipes-phosphor/mboxd/mboxd_git.bb
+++ b/meta-phosphor/recipes-phosphor/mboxd/mboxd_git.bb
@@ -14,7 +14,7 @@ DEPENDS += "phosphor-logging"
 
 S = "${WORKDIR}/git"
 
-SRC_URI += "git://github.com/openbmc/mboxbridge.git"
+SRC_URI += "git://github.com/openbmc/mboxbridge.git;branch=master;protocol=https"
 
 SRC_URI += "file://99-aspeed-lpc-ctrl.rules"
 SRC_URI += "file://aspeed-lpc-ctrl-h.patch"

--- a/meta-phosphor/recipes-phosphor/network/inarp_git.bb
+++ b/meta-phosphor/recipes-phosphor/network/inarp_git.bb
@@ -12,7 +12,7 @@ inherit obmc-phosphor-systemd
 DEPENDS += "autoconf-archive-native"
 RDEPENDS_${PN} += "phosphor-network"
 
-SRC_URI += "git://github.com/openbmc/inarp"
+SRC_URI += "git://github.com/openbmc/inarp;branch=master;protocol=https"
 SRCREV = "6d579909fc8e623e8a0dd6d4a32a4aee725c32f7"
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/recipes-phosphor/network/phosphor-snmp_git.bb
+++ b/meta-phosphor/recipes-phosphor/network/phosphor-snmp_git.bb
@@ -11,7 +11,7 @@ inherit obmc-phosphor-dbus-service
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
-SRC_URI += "git://github.com/ibm-openbmc/phosphor-snmp;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/phosphor-snmp;branch=OP940;protocol=https"
 SRCREV = "c06a82b62db97ac2ed5799047ae4e7d8bb8585bf"
 
 DBUS_SERVICE_${PN} += "xyz.openbmc_project.Network.SNMP.service"

--- a/meta-phosphor/recipes-phosphor/sel-logger/phosphor-sel-logger_git.bb
+++ b/meta-phosphor/recipes-phosphor/sel-logger/phosphor-sel-logger_git.bb
@@ -17,7 +17,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 DEPENDS += "systemd sdbusplus boost phosphor-ipmi-host"
 
-SRC_URI = "git://github.com/openbmc/phosphor-sel-logger.git;protocol=git"
+SRC_URI = "git://github.com/openbmc/phosphor-sel-logger.git;protocol=https;branch=master"
 SRCREV = "d9d78967503db2a02f2999c217c7c52183386298"
 
 PV = "0.1+git${SRCPV}"

--- a/meta-phosphor/recipes-phosphor/sensors/dbus-sensors_git.bb
+++ b/meta-phosphor/recipes-phosphor/sensors/dbus-sensors_git.bb
@@ -1,7 +1,7 @@
 SUMMARY = "dbus-sensors"
 DESCRIPTION = "Dbus Sensor Services Configured from D-Bus"
 
-SRC_URI = "git://github.com/openbmc/dbus-sensors.git"
+SRC_URI = "git://github.com/openbmc/dbus-sensors.git;branch=master;protocol=https"
 SRCREV = "be66441fbd7767659e0c37e41543d886bb31b457"
 
 PV = "0.1+git${SRCPV}"

--- a/meta-phosphor/recipes-phosphor/sensors/phosphor-hwmon_git.bb
+++ b/meta-phosphor/recipes-phosphor/sensors/phosphor-hwmon_git.bb
@@ -34,7 +34,7 @@ RRECOMMENDS_${PN} += "${VIRTUAL-RUNTIME_phosphor-hwmon-config}"
 FILES_max31785-msl = "${bindir}/max31785-msl"
 RDEPENDS_max31785-msl = "${VIRTUAL-RUNTIME_base-utils} i2c-tools"
 
-SRC_URI += "git://github.com/openbmc/phosphor-hwmon"
+SRC_URI += "git://github.com/openbmc/phosphor-hwmon;branch=master;protocol=https"
 SRC_URI += "file://70-hwmon.rules"
 SRC_URI += "file://70-iio.rules"
 SRC_URI += "file://start_hwmon.sh"

--- a/meta-phosphor/recipes-phosphor/settings/phosphor-settings-manager.inc
+++ b/meta-phosphor/recipes-phosphor/settings/phosphor-settings-manager.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "http://github.com/openbmc/phosphor-settingsd"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${S}/LICENSE;md5=fa818a259cbed7ce8bc2a22d35a464fc"
-SRC_URI += "git://github.com/ibm-openbmc/phosphor-settingsd;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/phosphor-settingsd;branch=OP940;protocol=https"
 SRCREV = "fbb07f675008b86a4200a5f50bf5300faff0c332"

--- a/meta-phosphor/recipes-phosphor/state/phosphor-state-manager_git.bb
+++ b/meta-phosphor/recipes-phosphor/state/phosphor-state-manager_git.bb
@@ -131,7 +131,7 @@ HOST_RST_RBT_ATTEMPTS_SVC_INST = "phosphor-reset-host-reboot-attempts@{0}.servic
 HOST_RST_RBT_ATTEMPTS_SVC_FMT = "../${HOST_RST_RBT_ATTEMPTS_SVC}:${HOST_START_TGTFMT}.requires/${HOST_RST_RBT_ATTEMPTS_SVC_INST}"
 SYSTEMD_LINK_${PN}-host += "${@compose_list_zip(d, 'HOST_RST_RBT_ATTEMPTS_SVC_FMT', 'OBMC_HOST_INSTANCES', 'OBMC_HOST_INSTANCES')}"
 
-SRC_URI += "git://github.com/ibm-openbmc/phosphor-state-manager;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/phosphor-state-manager;branch=OP940;protocol=https"
 SRCREV = "47c6636fd5cdd76ea5f3fd2b9ea9f07fa572d0f9"
 
 S = "${WORKDIR}/git"

--- a/meta-phosphor/recipes-phosphor/users/phosphor-user-manager_git.bb
+++ b/meta-phosphor/recipes-phosphor/users/phosphor-user-manager_git.bb
@@ -47,7 +47,7 @@ SYSTEMD_PACKAGES += "${PN}-expired-password"
 SYSTEMD_SERVICE_${PN}-expired-password += "first-boot-expire-password.service"
 
 SRC_URI += "file://add_groups_workaround.sh"
-SRC_URI += "git://github.com/ibm-openbmc/phosphor-user-manager;branch=OP940"
+SRC_URI += "git://github.com/ibm-openbmc/phosphor-user-manager;branch=OP940;protocol=https"
 SRCREV = "c10f815d8d29e702afbbbbbf6ae1807d1566274b"
 S = "${WORKDIR}/git"
 

--- a/meta-phosphor/recipes-phosphor/video/fbterm_git.bb
+++ b/meta-phosphor/recipes-phosphor/video/fbterm_git.bb
@@ -1,7 +1,7 @@
 HOMEPAGE = "https://github.com/jk-ozlabs/fbterm"
 LICENSE = "GPLv2+"
 
-SRC_URI += "git://github.com/jk-ozlabs/fbterm.git;nobranch=1"
+SRC_URI += "git://github.com/jk-ozlabs/fbterm.git;nobranch=1;protocol=https"
 SRC_URI += "file://fb.modes"
 PR = "r1"
 

--- a/meta-phosphor/recipes-phosphor/video/uart-render-controller_git.bb
+++ b/meta-phosphor/recipes-phosphor/video/uart-render-controller_git.bb
@@ -1,7 +1,7 @@
 HOMEPAGE = "https://github.com/jk-ozlabs/uart-render-controller"
 LICENSE = "GPLv2+"
 
-SRC_URI += "git://github.com/jk-ozlabs/uart-render-controller;branch=master"
+SRC_URI += "git://github.com/jk-ozlabs/uart-render-controller;branch=master;protocol=https"
 SRC_URI += "file://uart-render-controller.service"
 
 PR = "r1"

--- a/meta-phosphor/recipes-phosphor/watchdog/phosphor-watchdog_git.bb
+++ b/meta-phosphor/recipes-phosphor/watchdog/phosphor-watchdog_git.bb
@@ -19,7 +19,7 @@ DEPENDS += "phosphor-dbus-interfaces"
 DEPENDS += "phosphor-logging"
 DEPENDS += "systemd"
 
-SRC_URI += "git://github.com/openbmc/phosphor-watchdog"
+SRC_URI += "git://github.com/openbmc/phosphor-watchdog;branch=master;protocol=https"
 SRCREV = "c35135d32f9cb84b62de7b72eee3a2e87b4b3d4d"
 S = "${WORKDIR}/git"
 

--- a/meta-phosphor/recipes-phosphor/webui/phosphor-webui_git.bb
+++ b/meta-phosphor/recipes-phosphor/webui/phosphor-webui_git.bb
@@ -5,7 +5,7 @@ PV = "1.0+git${SRCPV}"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
-SRC_URI = "git://github.com/ibm-openbmc/phosphor-webui.git;branch=OP940"
+SRC_URI = "git://github.com/ibm-openbmc/phosphor-webui.git;branch=OP940;protocol=https"
 SRCREV = "c8d6244f02f55e8a3bb25d3c97e81d31e6b42389"
 S = "${WORKDIR}/git"
 

--- a/meta-phosphor/recipes-support/cjson/cjson_git.bb
+++ b/meta-phosphor/recipes-support/cjson/cjson_git.bb
@@ -1,7 +1,7 @@
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=218947f77e8cb8e2fa02918dc41c50d0"
 
-SRC_URI = "git://github.com/DaveGamble/cJSON.git"
+SRC_URI = "git://github.com/DaveGamble/cJSON.git;branch=master;protocol=https"
 
 PV = "1.7.6+git${SRCPV}"
 SRCREV = "cbc05de76fbd4dfff17b5626d5cfe9ec922b1f4a"


### PR DESCRIPTION
Per [1], Github turned off the unencrypted Git protocol.
Ran the upstream tool toautomatically fix URIs.

1. https://git.yoctoproject.org/poky/tree/documentation/migration-guides/migration-3.5.rst#n10

Signed-off-by: Pat Lin <Pat_Lin@wistron.com>