### PR TITLE
Update openssl and pdbg recipes

### DIFF
--- a/meta-openpower/recipes-bsp/pdbg/pdbg_3.1.bb
+++ b/meta-openpower/recipes-bsp/pdbg/pdbg_3.1.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://${S}/COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
 
 PV = "3.1+git${SRCPV}"
 
-SRC_URI += "git://github.com/open-power/pdbg.git"
+SRC_URI += "git://github.com/open-power/pdbg.git;branch=master;protocol=https"
 SRCREV = "v3.1"
 
 DEPENDS += "dtc-native"

--- a/poky/meta/recipes-connectivity/openssl/openssl_1.1.1n.bb
+++ b/poky/meta/recipes-connectivity/openssl/openssl_1.1.1n.bb
@@ -28,7 +28,7 @@ SRC_URI_append_riscv32 = " \
            file://0004-Fixup-support-for-io_pgetevents_time64-syscall.patch \
            "
 
-SRC_URI[sha256sum] = "892a0875b9872acd04a9fde79b1f943075d5ea162415de3047c327df33fbaee5"
+SRC_URI[sha256sum] = "40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a"
 
 inherit lib_package multilib_header multilib_script ptest
 MULTILIB_SCRIPTS = "${PN}-bin:${bindir}/c_rehash"


### PR DESCRIPTION
Update pdbg recipe to securely fetch.

Update openssl to 1.1.1n (was 1.1.1k).

Tested:
Compiled from scratch.
The squashfs size is below 19Mb.
Can connect via SSH, HTTPS, and ipmitool.

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>