### PR TITLE
p10bmc: Remove the BMC Minimum Ship Level

### DIFF
--- a/meta-ibm/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-ibm/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -16,7 +16,3 @@ PACKAGECONFIG:append:mihawk = " verify_signature"
 # Enable sync of persistent files to the alternate BMC chip
 PACKAGECONFIG:append:ibm-ac-server = " sync_bmc_files"
 PACKAGECONFIG:append:mihawk = " sync_bmc_files"
-
-# Set BMC Minimum Ship Level
-EXTRA_OEMESON:append:p10bmc = " -Dbmc-msl='fw1020.00-31'"
-EXTRA_OEMESON:append:p10bmc = " -Dregex-bmc-msl='([a-z]+[0-9]{2})+([0-9]+).([0-9]+).([0-9]+)'"


### PR DESCRIPTION
The p10bmc system doesn't need the restriction anymore that prevents
downgrades to an older firmware level.

Change-Id: Ia4f7b53bc97de05f7027b7bc35e2e055a9afa6bd
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>