### PR TITLE
meta-openpower: openpower-occ-control:disable test

### DIFF
--- a/meta-openpower/recipes-phosphor/occ/openpower-occ-control_git.bb
+++ b/meta-openpower/recipes-phosphor/occ/openpower-occ-control_git.bb
@@ -42,6 +42,7 @@ RDEPENDS:${PN} += "phosphor-state-manager-obmc-targets"
 EXTRA_OEMESON = " \
              -Dyamldir=${STAGING_DATADIR_NATIVE}/${PN} \
              -Dps-derating-factor=${POWER_SUPPLY_DERATING_FACTOR} \
+             -Dtests=disabled \
              "
 EXTRA_OEMESON:append = "${@bb.utils.contains('OBMC_MACHINE_FEATURES', 'i2c-occ', ' -Di2c-occ=enabled', '', d)}"
 


### PR DESCRIPTION
This test doesn't compile when I build the Romulus BMC. It's a convention that we disable test in Yocto builds.

refer: https://github.com/openbmc/openbmc/commit/d6c0eef5d8d630cad4f7daa61e8f8b79c01f5293

Signed-off-by: George Liu <liuxiwei@inspur.com>