### PR TITLE
The ibm-acf repo uses the ips branch by default

### DIFF
--- a/meta-ibm/recipes-phosphor/ibm-acf/ibm-acf.bb
+++ b/meta-ibm/recipes-phosphor/ibm-acf/ibm-acf.bb
@@ -3,8 +3,8 @@ PROVIDES += "ibm-acf"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=e3fc50a88d0a364313df4b21ef20c29e"
 
-SRC_URI = "git://github.com/ibm-openbmc/ibm-acf"
-SRCREV = "33318bfc8db0a370cac9266562f8a01b3b6c41f8"
+SRC_URI = "git://github.com/ibm-openbmc/ibm-acf;branch=1030.ips"
+SRCREV = "794eb0283341559dcae21173d74c36becacb5771"
 
 inherit meson
 #JSMN download required


### PR DESCRIPTION
Signed-off-by: George Liu <liuxiwei@inspur.com>