### PR TITLE
ips: Add Manufacturer to IPS branch

### DIFF
--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager-system.bb
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager-system.bb
@@ -1,0 +1,18 @@
+SUMMARY = "Add System interface for inventory manager"
+PR = "r1"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+inherit allarch
+inherit phosphor-inventory-manager
+
+PROVIDES += "virtual/phosphor-inventory-manager-system"
+S = "${WORKDIR}"
+
+SRC_URI = "file://system.yaml"
+
+do_install() {
+        install -D system.yaml ${D}${base_datadir}/events.d/system.yaml
+}
+
+FILES:${PN} += "${base_datadir}/events.d/system.yaml"

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager-system/system.yaml
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager-system/system.yaml
@@ -1,0 +1,13 @@
+events:
+    - name: Add System interface
+      description: >
+          Add the system interface on the system inventory path
+      type: startup
+      actions:
+          - name: createObjects
+            objs:
+              /system:
+                xyz.openbmc_project.Inventory.Decorator.Asset:
+                  Manufacturer:
+                    value: "Inspur Power Systems"
+                    type: string

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager_%.bbappend
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager_%.bbappend
@@ -4,6 +4,7 @@ SRC_URI:append:ibm-ac-server = " file://associations.json"
 DEPENDS:append:ibm-ac-server = " inventory-cleanup"
 
 PACKAGECONFIG:append:p10bmc = " associations"
+DEPENDS:append:p10bmc = " phosphor-inventory-manager-system"
 DEPENDS:append:p10bmc = " inventory-cleanup"
 DEPENDS:remove:p10bmc = " phosphor-inventory-manager-assettag"
 SRC_URI:append:p10bmc = " \


### PR DESCRIPTION
Since VPD does not obtain the Manufacturer of bmc, and on the IPS machine, the default Manufacturer is "Inspur Power Systems", so add a default value for Manufacturer.

Signed-off-by: George Liu <liuxiwei@inspur.com>