### PR TITLE
1050.00: entity-manager: downstream srcrev bump 1f302d72eb..d88b8bc129 & Pull in boost 1.81.0 & bmcweb: downstream srcrev bump ba77f029cc..3086ac5ca4

### DIFF
--- a/meta-phosphor/recipes-phosphor/configuration/entity-manager_git.bb
+++ b/meta-phosphor/recipes-phosphor/configuration/entity-manager_git.bb
@@ -13,7 +13,7 @@ DEPENDS = "boost \
            valijson \
            ${PYTHON_PN}-jsonschema-native \
 "
-SRCREV = "1f302d72eb0a9c90b1b6465e53b83cf7d60ff970"
+SRCREV = "d88b8bc1297953e08508904cbb42f6e1e80111c3"
 PACKAGECONFIG ??= "ipmi-fru"
 PACKAGECONFIG[ipmi-fru] = "-Dfru-device=true, -Dfru-device=false, i2c-tools,"
 PV = "0.1+git${SRCPV}"

--- a/meta-phosphor/recipes-phosphor/interfaces/bmcweb_git.bb
+++ b/meta-phosphor/recipes-phosphor/interfaces/bmcweb_git.bb
@@ -4,7 +4,6 @@ DEPENDS = " \
     openssl \
     zlib \
     boost \
-    boost-url \
     libpam \
     sdbusplus \
     gtest \

--- a/meta-phosphor/recipes-phosphor/interfaces/bmcweb_git.bb
+++ b/meta-phosphor/recipes-phosphor/interfaces/bmcweb_git.bb
@@ -13,7 +13,7 @@ DEPENDS = " \
     ${@bb.utils.contains('PTEST_ENABLED', '1', 'gtest', '', d)} \
     ${@bb.utils.contains('PTEST_ENABLED', '1', 'gmock', '', d)} \
 "
-SRCREV = "ba77f029ccbf0a62b1bbc4ae957578fed7676cff"
+SRCREV = "3086ac5ca4ad3218e1ff854499fb68e413ed6a95"
 PV = "1.0+git${SRCPV}"
 
 SRC_URI = "git://github.com/ibm-openbmc/bmcweb.git;protocol=https;nobranch=1;protocol=https"

--- a/meta-phosphor/recipes-support/boost/boost-1.81.0.inc
+++ b/meta-phosphor/recipes-support/boost/boost-1.81.0.inc
@@ -1,0 +1,20 @@
+# The Boost web site provides free peer-reviewed portable
+# C++ source libraries. The emphasis is on libraries which
+# work well with the C++ Standard Library. The libraries are
+# intended to be widely useful, and are in regular use by
+# thousands of programmers across a broad spectrum of applications.
+HOMEPAGE = "http://www.boost.org/"
+LICENSE = "BSL-1.0 & MIT & Python-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE_1_0.txt;md5=e4224ccaecb14d942c71d31bef20d78c"
+
+BOOST_VER = "${@"_".join(d.getVar("PV").split("."))}"
+BOOST_MAJ = "${@"_".join(d.getVar("PV").split(".")[0:2])}"
+BOOST_P = "boost_${BOOST_VER}"
+
+SRC_URI = "https://boostorg.jfrog.io/artifactory/main/release/${PV}/source/${BOOST_P}.tar.bz2"
+SRC_URI[sha256sum] = "71feeed900fbccca04a3b4f2f84a7c217186f28a940ed8b7ed4725986baf99fa"
+
+UPSTREAM_CHECK_URI = "http://www.boost.org/users/download/"
+UPSTREAM_CHECK_REGEX = "release/(?P<pver>.*)/source/"
+
+S = "${WORKDIR}/${BOOST_P}"

--- a/meta-phosphor/recipes-support/boost/boost.inc
+++ b/meta-phosphor/recipes-support/boost/boost.inc
@@ -1,0 +1,225 @@
+SUMMARY = "Free peer-reviewed portable C++ source libraries"
+DESCRIPTION = "Provides free peer-reviewed portable C++ source libraries.  The emphasis is on libraries which work well with the C++ \
+Standard Library.  One goal is to establish 'existing practice' and \
+provide reference implementations so that the Boost libraries are suitable for eventual standardization.  Some of the libraries have already been proposed for inclusion in the C++ Standards Committee's \
+upcoming C++ Standard Library Technical Report."
+SECTION = "libs"
+DEPENDS = "boost-build-native zlib bzip2"
+
+CVE_PRODUCT = "boost:boost"
+
+ARM_INSTRUCTION_SET:armv4 = "arm"
+ARM_INSTRUCTION_SET:armv5 = "arm"
+
+B = "${WORKDIR}/build"
+do_configure[cleandirs] = "${B}"
+
+BOOST_LIBS = "\
+	atomic \
+	chrono \
+	container \
+	context \
+	contract \
+	coroutine \
+	date_time \
+	exception \
+	fiber \
+	filesystem \
+	graph \
+	headers \
+	iostreams \
+	json \
+	log \
+	math \
+	program_options \
+	random \
+	regex \
+	serialization \
+	system \
+	test \
+	thread \
+	timer \
+	type_erasure \
+	wave \
+	"
+
+# optional libraries
+PACKAGECONFIG ??= "locale python"
+PACKAGECONFIG[locale] = ",,icu"
+PACKAGECONFIG[graph_parallel] = ",,,boost-mpi mpich"
+PACKAGECONFIG[mpi] = ",,mpich"
+PACKAGECONFIG[python] = ",,python3"
+
+BOOST_LIBS += "\
+    ${@bb.utils.filter('PACKAGECONFIG', 'locale python', d)} \
+    ${@bb.utils.contains('PACKAGECONFIG', 'graph_parallel', 'graph_parallel mpi', \
+                         bb.utils.filter('PACKAGECONFIG', 'mpi', d), d)} \
+"
+
+inherit python3-dir
+PYTHON_ROOT = "${STAGING_DIR_HOST}/${prefix}"
+
+# Make a package for each library, plus -dev
+PACKAGES = "${PN}-dbg ${BOOST_PACKAGES}"
+python __anonymous () {
+    packages = []
+    extras = []
+    pn = d.getVar("PN")
+    mlprefix = d.getVar("MLPREFIX")
+    for lib in d.getVar('BOOST_LIBS').split():
+        extras.append("--with-%s" % lib)
+        pkg = "boost-%s" % (lib.replace("_", "-"))
+        if "-native" in pn:
+            pkg = pkg + "-native"
+        packages.append(mlprefix + pkg)
+        if not d.getVar("FILES:%s" % pkg):
+                d.setVar("FILES:%s%s" % (mlprefix, pkg), "${libdir}/libboost_%s*.so.*" % lib)
+        else:
+                d.setVar("FILES:%s%s" % (mlprefix, pkg), d.getVar("FILES:%s" % pkg))
+
+    d.setVar("BOOST_PACKAGES", " ".join(packages))
+    d.setVar("BJAM_EXTRA", " ".join(extras))
+}
+
+# Override the contents of specific packages
+FILES:${PN}-graph_parallel = "${libdir}/libboost_graph_parallel.so.*"
+FILES:${PN}-locale = "${libdir}/libboost_locale.so.*"
+FILES:${PN}-mpi = "${libdir}/mpi.so ${libdir}/libboost_mpi*.so.*"
+FILES:boost-serialization = "${libdir}/libboost_serialization*.so.* \
+	${libdir}/libboost_wserialization*.so.*"
+FILES:boost-test = "${libdir}/libboost_prg_exec_monitor*.so.* \
+	${libdir}/libboost_unit_test_framework*.so.*"
+
+# -dev last to pick up the remaining stuff
+PACKAGES += "${PN}-dev ${PN}-staticdev"
+FILES:${PN}-dev = "${includedir} ${libdir}/libboost_*.so ${libdir}/cmake"
+FILES:${PN}-staticdev = "${libdir}/libboost_*.a"
+
+# "boost" is a metapackage which pulls in all boost librabries
+PACKAGES += "${PN}"
+FILES:${PN} = ""
+ALLOW_EMPTY:${PN} = "1"
+RRECOMMENDS:${PN} += "${BOOST_PACKAGES}"
+RRECOMMENDS:${PN}:class-native = ""
+
+# to avoid GNU_HASH QA errors added LDFLAGS to ARCH; a little bit dirty but at least it works
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+# Oh yippee, a new build system, it's sooo cooool I could eat my own
+# foot.  inlining=on lets the compiler choose, I think.  At least this
+# stuff is documented...
+# NOTE: if you leave <debug-symbols>on then in a debug build the build sys
+# objcopy will be invoked, and that won't work.  Building debug apparently
+# requires hacking gcc-tools.jam
+#
+# Sometimes I wake up screaming.  Famous figures are gathered in the nightmare,
+# Steve Bourne, Larry Wall, the whole of the ANSI C committee.  They're just
+# standing there, waiting, but the truely terrifying thing is what they carry
+# in their hands.  At first sight each seems to bear the same thing, but it is
+# not so for the forms in their grasp are ever so slightly different one from
+# the other.  Each is twisted in some grotesque way from the other to make each
+# an unspeakable perversion impossible to perceive without the onset of madness.
+# True insanity awaits anyone who perceives all of these horrors together.
+#
+# Quotation marks, there might be an easier way to do this, but I can't find
+# it.  The problem is that the user.hpp configuration file must receive a
+# pre-processor macro defined as the appropriate string - complete with "'s
+# around it.  (<> is a possibility here but the danger to that is that the
+# failure case interprets the < and > as shell redirections, creating
+# random files in the source tree.)
+#
+#bjam: '-DBOOST_PLATFORM_CONFIG=\"config\"'
+#do_compile: '-sGCC=... '"'-DBOOST_PLATFORM_CONFIG=\"config\"'"
+SQD = '"'
+EQD = '\"'
+#boost.bb:   "...  '-sGCC=... '${SQD}'-DBOOST_PLATFORM_CONFIG=${EQD}config${EQD}'${SQD} ..."
+BJAM_CONF = "${SQD}'-DBOOST_PLATFORM_CONFIG=${EQD}boost/config/platform/${TARGET_OS}.hpp${EQD}'${SQD}"
+
+BJAM_TOOLS   = "--ignore-site-config \
+		'-sTOOLS=gcc' \
+		'-sGCC=${CC} '${BJAM_CONF} \
+		'-sGXX=${CXX} '${BJAM_CONF} \
+		'-sGCC_INCLUDE_DIRECTORY=${STAGING_INCDIR}' \
+		'-sGCC_STDLIB_DIRECTORY=${STAGING_LIBDIR}' \
+		'-sBUILD=release <optimization>space <threading>multi <inlining>on <debug-symbols>off' \
+		'-sPYTHON_ROOT=${PYTHON_ROOT}' \
+		'--layout=system' \
+		"
+
+# use PARALLEL_MAKE to speed up the build
+BOOST_PARALLEL_MAKE = "${@oe.utils.parallel_make_argument(d, '-j%d')}"
+BJAM_OPTS    = '${BOOST_PARALLEL_MAKE} -d+2 -q \
+		${BJAM_TOOLS} \
+		-sBOOST_BUILD_USER_CONFIG=${WORKDIR}/user-config.jam \
+		-sICU_PATH=${STAGING_EXECPREFIXDIR} \
+		--build-dir=${B} \
+		--disable-icu \
+		${BJAM_EXTRA}'
+
+# Native compilation of bzip2 isn't working
+BJAM_OPTS:append:class-native = ' -sNO_BZIP2=1'
+
+# Adjust the build for x32
+BJAM_OPTS:append:x86-x32 = " abi=x32 address-model=64"
+
+# cross compiling for arm fails to detect abi, so provide some help
+BJAM_OPTS:append:arm = " abi=aapcs architecture=arm"
+BJAM_OPTS:append:aarch64 = " abi=aapcs address-model=64 architecture=arm"
+
+do_configure() {
+	cd ${S}
+	cp -f ${S}/boost/config/platform/linux.hpp ${S}/boost/config/platform/linux-gnueabi.hpp
+
+	# D2194:Fixing the failure of "error: duplicate initialization of gcc with the following parameters" during compilation.
+	rm -f ${WORKDIR}/user-config.jam
+	echo 'using gcc : : ${CXX} : <cflags>"${CFLAGS}" <cxxflags>"${CXXFLAGS}" <linkflags>"${LDFLAGS}" ;' >> ${WORKDIR}/user-config.jam
+
+	# If we want Python then we need to tell Boost *exactly* where to find it
+	if ${@bb.utils.contains('BOOST_LIBS', 'python', 'true', 'false', d)}; then
+		echo "using python : ${PYTHON_BASEVERSION} : ${STAGING_DIR_HOST}${bindir}/python3 : ${STAGING_DIR_HOST}${includedir}/${PYTHON_DIR}${PYTHON_ABI} : ${STAGING_DIR_HOST}${libdir}/${PYTHON_DIR} ;" >> ${WORKDIR}/user-config.jam
+	fi
+
+	if ${@bb.utils.contains('BOOST_LIBS', 'mpi', 'true', 'false', d)}; then
+		echo "using mpi : : <find-shared-library>mpi ;" >> ${WORKDIR}/user-config.jam
+	fi
+
+	CC="${BUILD_CC}" CFLAGS="${BUILD_CFLAGS}" ./bootstrap.sh --with-bjam=b2 --with-toolset=gcc
+
+	# Boost can't be trusted to find Python on it's own, so remove any mention
+	# of it from the boost configuration
+	sed -i '/using python/d' ${S}/project-config.jam
+}
+
+do_compile() {
+	cd ${S}
+	b2 ${BJAM_OPTS} \
+		--prefix=${prefix} \
+		--exec-prefix=${exec_prefix} \
+		--libdir=${libdir} \
+		--includedir=${includedir} \
+		--debug-configuration
+}
+
+do_install() {
+	cd ${S}
+	b2 ${BJAM_OPTS} \
+		--libdir=${D}${libdir} \
+		--includedir=${D}${includedir} \
+		install
+	for lib in ${BOOST_LIBS}; do
+		if [ -e ${D}${libdir}/libboost_${lib}.a ]; then
+			ln -s libboost_${lib}.a ${D}${libdir}/libboost_${lib}-mt.a
+		fi
+		if [ -e ${D}${libdir}/libboost_${lib}.so ]; then
+			ln -s libboost_${lib}.so ${D}${libdir}/libboost_${lib}-mt.so
+		fi
+	done
+
+        # Cmake files reference full paths to image
+        find ${D}${libdir}/cmake -type f | \
+             grep 'cmake$' | \
+             xargs -n 1 sed -e 's,${D}${libdir}/cmake,${libdir}/cmake,' -i
+
+}
+
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-phosphor/recipes-support/boost/boost_1.81.0.bb
+++ b/meta-phosphor/recipes-support/boost/boost_1.81.0.bb
@@ -1,0 +1,3 @@
+require boost-${PV}.inc
+require boost.inc
+


### PR DESCRIPTION
#### entity-manager: downstream srcrev bump 1f302d72eb..d88b8bc129
```
Bonnie Lo (1):
  schemas: Add properties for pid and pid_zone

Matthew Barth (2):
  configs:Storm King: Update ambient thresholds
  configs: Blyth & Storm King ambient sensor thresholds

Kumar Thangavel (2):
  Add a helper function copyRestFRUArea to updateFRUProperty
  Refactor : Add a helper function findIndexForFRU to

Jim Wright (2):
  Add support for 110v input voltage on 2000W power supply
  Allow 2 PS in Rainier 1s4u 1000W configuration

Joel Stanley (1):
  configs: Update RTC battery pin to upstream name

Rashmica Gupta (1):
  storm king: Add Ambient Virtual Temperature Sensor

Jayashree Dhanapal (1):
  Add a new configuration file for Twinlake board

Andrew Geissler (3):
  format: misc changes needed in downstream patches
  Merge branch '1050' into 1050-upstream-rebase
  Merge pull request #40 from geissonator/1050-upstream-rebase

Joseph Fu (1):
  devices: add ADS1015 support

Adriana Kobylak (7):
  Add supported_configuration schema
  Add SupportedConfiguration to Rainier2U
  Add SupportedConfiguration to Rainier2S4U
  Add SupportedConfiguration to Rainier1S4U
  Add SupportedConfiguration to Everest
  everest: Change PSU model from 51EA to 51DA
  Supported Configuration: Add PowerConfigFullLoad

AKSHAY RAVEENDRAN K (1):
  Add reading FRU support from different MUX channel

Chris Cain (2):
  schema: ibm: add default power mode props. schema (#18)
  schema: ibm: correct ExitUtilizationDwellTime (#30)

Santosh Puranik (1):
  entity-manager: Failsafe for scan callback timer (#29)

Andrew Jeffery (2):
  configurations: Add PM1735 NVMe device for IBM systems
  configurations: Fix misleading drive model name (#31)

Potin Lai (1):
  configurations: add bletchley frontpanel configuration

Patrick Williams (5):
  schemas: move README as markdown
  python: fix flake8 warnings
  format: reformat with latest openbmc-build-scripts
  markdownlint: fix all warnings
  clang-ignore: remove unneeded file

Tom Ippolito (3):
  New JSON file to enable ADC read of Rainier battery voltage
  New JSON file to enable ADC read of Everest battery voltage
  Adjusted battery low trip point for Rainier and Everest systems

Sunny Srivastava (1):
  Skip Item.Chassis interface under chassis object (#26)

krishnar4 (1):
  Fru-device : Extended support for 16bit logic bus

Matt Spinler (8):
  ibm: Change TMP275 temp sensor poll rate to 1s
  Remove PM1735 lower thresholds (#13)
  Add IBM PCIe cards
  Revert "Remove PM1735 lower thresholds (#13)"
  Revert "Revert: Remove PM1735 lower thresholds"
  configs:Flett: Update temperature threshold
  configs:ibm: Rename PCIe card temp sensors
  configs:ibm: Virtual ambient hysteresis updates

Change-Id: I96704e7673f44a0c2d7d2907314ade39a0442bd0
```
#### Pull in boost 1.81.0
```
Boost 1.81.0 has some very good changes for us, as it drops the
boost-url beta dependency, in leiu of standard boost.  Because it has
some breaking API changes, it seems like a good idea to get ahead of it,
and pull in the update a few weeks ahead of time.  Looking through the
changelogs, there's nothing in the modules that we use that would pose
any concern for us, aside from the boost-url changes, which is the point
of this commit.

This needs to go hand in hand with:
https://gerrit.openbmc.org/c/openbmc/bmcweb/+/55021

Signed-off-by: Ed Tanous <edtanous@google.com>
Change-Id: I71c629878f386849f8af1e9cb3e6926d3b19f3f9
```
#### bmcweb: downstream srcrev bump ba77f029cc..3086ac5ca4
```
Albert Zhang (1):
  Add Redfish EnvironmentMetrics schema in bmcweb

Sunitha Harish (1):
  Push-style Event Dbus Monitor support

Asmitha Karunanithi (2):
  Remove support for priv-noaccess role
  Add BIOS support

patelabhishek9893 (1):
  Fix OemLogEntry Schema

Noah Brewer (1):
  Accounts/service ACF properties added

Andrew Geissler (2):
  OemManagerAccount: update for new upstream format rules
  Merge branch '1050' into 1050-upstream-rebase-new-boost

Carson Labrado (1):
  Aggregation: Detect and fix all URI properties

Abhishek Patel (2):
  Retrive chassis Assembly Interface
  BMC_SHELL web-base_shell

Jiaqing Zhao (1):
  log_service: Fix behavior of getting single PostCode entry

Edward Lee (1):
  Code move to prevent circular dependency

George Liu (4):
  Add Link header handling to PowerSubsystem
  Add Link header handling to ThermalSubsystem
  Add the GetSubTree and GetSubTreePaths method to dbus_utility
  Add Accuracy property to sensors

aahmed-2 (4):
  Remove BootSource and BootMode for GA (#209)
  Add CableStatus, Status.State, Status.Health (#357)
  Add PartNumber to Cables (#394)
  Add call to getPELJson interface

Ali Ahmed (1):
  Create Event Subscription meson build option

Vijay Lobo (2):
  Add properties from LogEntry
  Add HMC acknowledgement support

cm-jishnu (1):
  Restrict use of subfolder in configfiles path

Gayathri Leburu (1):
  Fix for incorrect Task Progress and State values

Gunnar Mills (8):
  Allow a lower DeliveryRetryIntervalSeconds
  Merge pull request #483 from sbteeks/abhi_a7166a6b_bmc_shell
  Bump timeout for code update file to 55 (#436)
  Bump the max password length to 64 (#437)
  Remove health.hpp calls where unneeded (#237)
  Increase bmcweb automatic restart (#356)
  Bump connection timeout to 26 mins
  Merge pull request #486 from geissonator/1050-upstream-rebase-new-boost

tomippolito (1):
  Update to fix SW544220. (#339)

Potin Lai (1):
  managers: fix interface patch and delete of pid object

Patrick Williams (6):
  sdbusplus: use shorter type aliases
  python: fix flake8 warnings
  format: reformat with latest openbmc-build-scripts
  markdownlint: fix all warnings
  clang-ignore: remove unneeded file
  black: re-format

Jian Zhang (1):
  Correct the dhcp object path

Sunny Srivastava (1):
  Unauthorized ACF certificate upload (#243)

Johnathan Mantey (1):
  Prevent unconditionally writing over the LinkStatus

Shantappa Teekappanavar (4):
  Populate cable properties if length is NaN
  bmcweb: Add support for CE Event Log
  Fix bmcweb build failure
  Add OemServiceRoot schema

Nan Zhou (1):
  OWNERS: fix minor path issue

Ed Tanous (9):
  Fix NTPServers property in Redfish
  Make router take up less space for verbs
  Implement If-Match header in Http layer
  Generate Redfish enums from schemas
  Remove ObjectManager search code in sensors
  Make inventory get inventory paths
  Fix python packaging problem
  Mark redfish-protocol-validator 100% passing
  Prepare for boost::url upgrade

Tony Lee (1):
  pcie:Fix get PCIeFunction

Joseph Reynolds (1):
  Add new Redfish role OemIBMServiceAgent

Matt Spinler (1):
  D-Bus event log entry: fix bool types

Change-Id: I7766cab37445e7475a46628815f890a0b87cd7ac
```