### PR TITLE
Add org/freedesktop

### DIFF
--- a/meta-ibm/conf/distro/include/ibm-yaml.inc
+++ b/meta-ibm/conf/distro/include/ibm-yaml.inc
@@ -1,1 +1,1 @@
-OBMC_ORG_YAML_SUBDIRS += " com/ibm"
+OBMC_ORG_YAML_SUBDIRS += " com/ibm org/freedesktop"


### PR DESCRIPTION
IBM enbale org/freedesktop by default, otherwise the compilation image will fail because PDI cannot be found.

Signed-off-by: George Liu <liuxiwei@inspur.com>