### PR TITLE
meta-ibm: p10bmc: Update the association between Fan and Chassis

### DIFF
--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/associations.json
@@ -105,6 +105,15 @@
                 [
                     "/xyz/openbmc_project/led/physical/fan0"
                 ]
+            },
+            {
+                "types": {
+                    "rType": "cooled_by",
+                    "fType": "cooling"
+                },
+                "paths": [
+                    "/xyz/openbmc_project/inventory/system/chassis"
+                ]
             }
         ]
     },
@@ -133,6 +142,15 @@
                 "paths":
                 [
                     "/xyz/openbmc_project/led/physical/fan1"
+                ]
+            },
+            {
+                "types": {
+                    "rType": "cooled_by",
+                    "fType": "cooling"
+                },
+                "paths": [
+                    "/xyz/openbmc_project/inventory/system/chassis"
                 ]
             }
         ]
@@ -163,6 +181,15 @@
                 [
                     "/xyz/openbmc_project/led/physical/fan2"
                 ]
+            },
+            {
+                "types": {
+                    "rType": "cooled_by",
+                    "fType": "cooling"
+                },
+                "paths": [
+                    "/xyz/openbmc_project/inventory/system/chassis"
+                ]
             }
         ]
     },
@@ -191,6 +218,15 @@
                 "paths":
                 [
                     "/xyz/openbmc_project/led/physical/fan3"
+                ]
+            },
+            {
+                "types": {
+                    "rType": "cooled_by",
+                    "fType": "cooling"
+                },
+                "paths": [
+                    "/xyz/openbmc_project/inventory/system/chassis"
                 ]
             }
         ]

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,everest_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,everest_associations.json
@@ -51,8 +51,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -102,8 +102,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -153,8 +153,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -204,8 +204,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-2u_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-2u_associations.json
@@ -52,8 +52,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -103,8 +103,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -154,8 +154,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -205,8 +205,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -256,8 +256,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -307,8 +307,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-4u_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-4u_associations.json
@@ -51,8 +51,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -101,8 +101,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -151,8 +151,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -201,8 +201,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -251,8 +251,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [
@@ -301,8 +301,8 @@
                 {
                     "types":
                     {
-                        "rType": "inventory",
-                        "fType": "chassis"
+                        "rType": "cooled_by",
+                        "fType": "cooling"
                     },
                     "paths":
                     [


### PR DESCRIPTION
Per association document[1], add/update the association between Fan and Chassis.

[1] https://github.com/openbmc/phosphor-dbus-interfaces/commit/d0aa13b446ee1738d53fb1e04341946f5b0b7616

Signed-off-by: George Liu <liuxiwei@inspur.com>