### PR TITLE
1050.00: Update `fault identify` & `identify` association

### DIFF
--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,bonnell_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,bonnell_associations.json
@@ -28,8 +28,8 @@
             },
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/fan0_fault"
@@ -70,8 +70,8 @@
             },
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/fan1_fault"
@@ -102,8 +102,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -193,8 +193,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/partition_system_attention_indicator",
@@ -286,8 +286,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -319,8 +319,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -355,8 +355,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -378,8 +378,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -410,8 +410,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -433,8 +433,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -456,8 +456,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -479,8 +479,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -502,8 +502,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -525,8 +525,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -557,8 +557,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -580,8 +580,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -621,8 +621,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -662,8 +662,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -703,8 +703,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_fault"
@@ -744,8 +744,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/nvme0_fault"
@@ -785,8 +785,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/nvme1_fault"
@@ -826,8 +826,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/nvme2_fault"
@@ -867,8 +867,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"fault_inventory_object",
-                  "fType":"fault_led_group"
+                  "rType":"fault_identified_by",
+                  "fType":"fault_identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/nvme3_fault"

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,bonnell_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,bonnell_associations.json
@@ -37,8 +37,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/fan0_identify"
@@ -79,8 +79,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/fan1_identify"
@@ -111,8 +111,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -295,8 +295,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -328,8 +328,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -364,8 +364,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -387,8 +387,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -396,8 +396,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -419,8 +419,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -442,8 +442,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -465,8 +465,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -488,8 +488,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -511,8 +511,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -534,8 +534,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -566,8 +566,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -589,8 +589,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -630,8 +630,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -671,8 +671,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -712,8 +712,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -753,8 +753,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/nvme0_identify"
@@ -794,8 +794,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/nvme1_identify"
@@ -835,8 +835,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/nvme2_identify"
@@ -876,8 +876,8 @@
             },
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/nvme3_identify"
@@ -908,8 +908,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -931,8 +931,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -954,8 +954,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -977,8 +977,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -1000,8 +1000,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -1023,8 +1023,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -1046,8 +1046,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -1069,8 +1069,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -1092,8 +1092,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -1115,8 +1115,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -1138,8 +1138,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -1161,8 +1161,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -1184,8 +1184,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
@@ -1207,8 +1207,8 @@
          "endpoints":[
             {
                "types":{
-                  "rType":"identify_inventory_object",
-                  "fType":"identify_led_group"
+                  "rType":"identified_by",
+                  "fType":"identifying"
                },
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,everest_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,everest_associations.json
@@ -40,8 +40,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -91,8 +91,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -142,8 +142,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -193,8 +193,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -232,8 +232,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -449,8 +449,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -517,8 +517,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -585,8 +585,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -653,8 +653,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -692,8 +692,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -720,8 +720,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -748,8 +748,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -776,8 +776,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -804,8 +804,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -832,8 +832,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -860,8 +860,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -888,8 +888,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -916,8 +916,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -944,8 +944,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -972,8 +972,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1198,8 +1198,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1226,8 +1226,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1254,8 +1254,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1282,8 +1282,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1310,8 +1310,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1338,8 +1338,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1366,8 +1366,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1394,8 +1394,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1422,8 +1422,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1450,8 +1450,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1478,8 +1478,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1506,8 +1506,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1534,8 +1534,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1562,8 +1562,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1590,8 +1590,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1618,8 +1618,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1646,8 +1646,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1674,8 +1674,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1702,8 +1702,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1742,8 +1742,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1770,8 +1770,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1809,8 +1809,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1837,8 +1837,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1865,8 +1865,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1893,8 +1893,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1921,8 +1921,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1949,8 +1949,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1977,8 +1977,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2005,8 +2005,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2033,8 +2033,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2061,8 +2061,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2089,8 +2089,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2117,8 +2117,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2145,8 +2145,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2173,8 +2173,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2201,8 +2201,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2229,8 +2229,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2257,8 +2257,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2285,8 +2285,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2313,8 +2313,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2341,8 +2341,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2369,8 +2369,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2397,8 +2397,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2425,8 +2425,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2453,8 +2453,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2481,8 +2481,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2509,8 +2509,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2537,8 +2537,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2565,8 +2565,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2593,8 +2593,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2621,8 +2621,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2649,8 +2649,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2677,8 +2677,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2705,8 +2705,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2733,8 +2733,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2761,8 +2761,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2789,8 +2789,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2817,8 +2817,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2845,8 +2845,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2873,8 +2873,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2901,8 +2901,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2929,8 +2929,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2957,8 +2957,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2985,8 +2985,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3013,8 +3013,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3041,8 +3041,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3069,8 +3069,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3097,8 +3097,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3125,8 +3125,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3153,8 +3153,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3181,8 +3181,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3209,8 +3209,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3237,8 +3237,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3265,8 +3265,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3293,8 +3293,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3321,8 +3321,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3349,8 +3349,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3377,8 +3377,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3405,8 +3405,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3433,8 +3433,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3461,8 +3461,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3489,8 +3489,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3517,8 +3517,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3545,8 +3545,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3573,8 +3573,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3601,8 +3601,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3629,8 +3629,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3657,8 +3657,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3685,8 +3685,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3713,8 +3713,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3741,8 +3741,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3769,8 +3769,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3797,8 +3797,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3825,8 +3825,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3853,8 +3853,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3881,8 +3881,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3909,8 +3909,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3937,8 +3937,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3965,8 +3965,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3993,8 +3993,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4021,8 +4021,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4049,8 +4049,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4077,8 +4077,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4105,8 +4105,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4133,8 +4133,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4161,8 +4161,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4189,8 +4189,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4217,8 +4217,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4245,8 +4245,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4273,8 +4273,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4301,8 +4301,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4329,8 +4329,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4357,8 +4357,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4385,8 +4385,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4413,8 +4413,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4441,8 +4441,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4469,8 +4469,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4497,8 +4497,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4525,8 +4525,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4553,8 +4553,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4581,8 +4581,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4609,8 +4609,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4652,8 +4652,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4680,8 +4680,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4719,8 +4719,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4758,8 +4758,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4797,8 +4797,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4836,8 +4836,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4875,8 +4875,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4903,8 +4903,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4931,8 +4931,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4959,8 +4959,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4987,8 +4987,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5015,8 +5015,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5043,8 +5043,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5071,8 +5071,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5099,8 +5099,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,everest_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,everest_associations.json
@@ -29,8 +29,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -80,8 +80,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -131,8 +131,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -182,8 +182,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -221,8 +221,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -391,8 +391,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -438,8 +438,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -506,8 +506,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -574,8 +574,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -642,8 +642,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -681,8 +681,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -709,8 +709,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -737,8 +737,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -765,8 +765,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -793,8 +793,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -821,8 +821,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -849,8 +849,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -877,8 +877,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -905,8 +905,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -933,8 +933,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -961,8 +961,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1187,8 +1187,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1215,8 +1215,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1243,8 +1243,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1271,8 +1271,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1299,8 +1299,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1327,8 +1327,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1355,8 +1355,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1383,8 +1383,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1411,8 +1411,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1439,8 +1439,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1467,8 +1467,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1495,8 +1495,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1523,8 +1523,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1551,8 +1551,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1579,8 +1579,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1607,8 +1607,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1635,8 +1635,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1663,8 +1663,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1691,8 +1691,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1731,8 +1731,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1759,8 +1759,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1798,8 +1798,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1826,8 +1826,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1854,8 +1854,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1882,8 +1882,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1910,8 +1910,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1938,8 +1938,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1966,8 +1966,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1994,8 +1994,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2022,8 +2022,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2050,8 +2050,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2078,8 +2078,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2106,8 +2106,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2134,8 +2134,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2162,8 +2162,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2190,8 +2190,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2218,8 +2218,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2246,8 +2246,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2274,8 +2274,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2302,8 +2302,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2330,8 +2330,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2358,8 +2358,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2386,8 +2386,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2414,8 +2414,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2442,8 +2442,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2470,8 +2470,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2498,8 +2498,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2526,8 +2526,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2554,8 +2554,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2582,8 +2582,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2610,8 +2610,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2638,8 +2638,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2666,8 +2666,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2694,8 +2694,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2722,8 +2722,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2750,8 +2750,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2778,8 +2778,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2806,8 +2806,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2834,8 +2834,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2862,8 +2862,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2890,8 +2890,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2918,8 +2918,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2946,8 +2946,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2974,8 +2974,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3002,8 +3002,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3030,8 +3030,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3058,8 +3058,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3086,8 +3086,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3114,8 +3114,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3142,8 +3142,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3170,8 +3170,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3198,8 +3198,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3226,8 +3226,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3254,8 +3254,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3282,8 +3282,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3310,8 +3310,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3338,8 +3338,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3366,8 +3366,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3394,8 +3394,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3422,8 +3422,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3450,8 +3450,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3478,8 +3478,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3506,8 +3506,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3534,8 +3534,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3562,8 +3562,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3590,8 +3590,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3618,8 +3618,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3646,8 +3646,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3674,8 +3674,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3702,8 +3702,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3730,8 +3730,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3758,8 +3758,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3786,8 +3786,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3814,8 +3814,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3842,8 +3842,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3870,8 +3870,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3898,8 +3898,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3926,8 +3926,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3954,8 +3954,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3982,8 +3982,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4010,8 +4010,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4038,8 +4038,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4066,8 +4066,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4094,8 +4094,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4122,8 +4122,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4150,8 +4150,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4178,8 +4178,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4206,8 +4206,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4234,8 +4234,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4262,8 +4262,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4290,8 +4290,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4318,8 +4318,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4346,8 +4346,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4374,8 +4374,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4402,8 +4402,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4430,8 +4430,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4458,8 +4458,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4486,8 +4486,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4514,8 +4514,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4542,8 +4542,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4570,8 +4570,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4598,8 +4598,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4641,8 +4641,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4669,8 +4669,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4708,8 +4708,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4747,8 +4747,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4786,8 +4786,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4825,8 +4825,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -4864,8 +4864,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-2u_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-2u_associations.json
@@ -30,8 +30,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -81,8 +81,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -132,8 +132,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -183,8 +183,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -234,8 +234,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -285,8 +285,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -324,8 +324,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -452,8 +452,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -499,8 +499,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -567,8 +567,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -606,8 +606,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -646,8 +646,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -689,8 +689,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -717,8 +717,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -745,8 +745,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -773,8 +773,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -801,8 +801,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -829,8 +829,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -857,8 +857,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -885,8 +885,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -913,8 +913,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -941,8 +941,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -969,8 +969,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -997,8 +997,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1025,8 +1025,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1053,8 +1053,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1081,8 +1081,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1109,8 +1109,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1137,8 +1137,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1165,8 +1165,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1193,8 +1193,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1221,8 +1221,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1249,8 +1249,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1277,8 +1277,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1305,8 +1305,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1333,8 +1333,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1361,8 +1361,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1389,8 +1389,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1417,8 +1417,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1445,8 +1445,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1473,8 +1473,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1501,8 +1501,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1529,8 +1529,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1557,8 +1557,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1585,8 +1585,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1613,8 +1613,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1641,8 +1641,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1669,8 +1669,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1697,8 +1697,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1725,8 +1725,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1753,8 +1753,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1781,8 +1781,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1809,8 +1809,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1848,8 +1848,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1876,8 +1876,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1926,8 +1926,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1976,8 +1976,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2026,8 +2026,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2076,8 +2076,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2126,8 +2126,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2165,8 +2165,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2215,8 +2215,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2265,8 +2265,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2315,8 +2315,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2365,8 +2365,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2621,8 +2621,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2649,8 +2649,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2677,8 +2677,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2705,8 +2705,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2733,8 +2733,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2761,8 +2761,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2789,8 +2789,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2817,8 +2817,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2845,8 +2845,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2873,8 +2873,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2901,8 +2901,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2951,8 +2951,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3001,8 +3001,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3051,8 +3051,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3101,8 +3101,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3151,8 +3151,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3201,8 +3201,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3251,8 +3251,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-2u_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-2u_associations.json
@@ -41,8 +41,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -92,8 +92,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -143,8 +143,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -194,8 +194,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -245,8 +245,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -296,8 +296,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -335,8 +335,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -510,8 +510,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -578,8 +578,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -617,8 +617,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -657,8 +657,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -700,8 +700,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -728,8 +728,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -756,8 +756,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -784,8 +784,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -812,8 +812,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -840,8 +840,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -868,8 +868,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -896,8 +896,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -924,8 +924,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -952,8 +952,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -980,8 +980,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1008,8 +1008,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1036,8 +1036,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1064,8 +1064,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1092,8 +1092,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1120,8 +1120,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1148,8 +1148,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1176,8 +1176,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1204,8 +1204,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1232,8 +1232,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1260,8 +1260,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1288,8 +1288,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1316,8 +1316,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1344,8 +1344,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1372,8 +1372,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1400,8 +1400,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1428,8 +1428,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1456,8 +1456,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1484,8 +1484,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1512,8 +1512,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1540,8 +1540,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1568,8 +1568,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1596,8 +1596,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1624,8 +1624,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1652,8 +1652,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1680,8 +1680,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1708,8 +1708,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1736,8 +1736,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1764,8 +1764,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1792,8 +1792,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1820,8 +1820,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1859,8 +1859,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1887,8 +1887,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1937,8 +1937,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1987,8 +1987,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2037,8 +2037,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2087,8 +2087,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2137,8 +2137,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2176,8 +2176,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2226,8 +2226,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2276,8 +2276,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2326,8 +2326,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2376,8 +2376,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2632,8 +2632,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2660,8 +2660,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2688,8 +2688,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2716,8 +2716,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2744,8 +2744,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2772,8 +2772,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2800,8 +2800,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2828,8 +2828,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2856,8 +2856,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2884,8 +2884,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2912,8 +2912,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2962,8 +2962,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3012,8 +3012,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3062,8 +3062,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3112,8 +3112,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3162,8 +3162,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3212,8 +3212,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3262,8 +3262,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3301,8 +3301,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3329,8 +3329,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3357,8 +3357,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3385,8 +3385,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3413,8 +3413,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3441,8 +3441,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3469,8 +3469,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3497,8 +3497,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3525,8 +3525,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3553,8 +3553,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3581,8 +3581,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3609,8 +3609,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3637,8 +3637,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3665,8 +3665,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3693,8 +3693,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3721,8 +3721,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3749,8 +3749,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3777,8 +3777,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3805,8 +3805,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3833,8 +3833,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3861,8 +3861,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3889,8 +3889,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3917,8 +3917,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3945,8 +3945,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3973,8 +3973,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4001,8 +4001,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4029,8 +4029,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4057,8 +4057,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4085,8 +4085,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4113,8 +4113,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4141,8 +4141,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4169,8 +4169,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4197,8 +4197,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4225,8 +4225,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4253,8 +4253,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4281,8 +4281,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4309,8 +4309,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4337,8 +4337,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4365,8 +4365,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4393,8 +4393,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4421,8 +4421,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4449,8 +4449,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4477,8 +4477,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4505,8 +4505,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4533,8 +4533,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4561,8 +4561,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4589,8 +4589,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4617,8 +4617,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4645,8 +4645,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4673,8 +4673,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-4u_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-4u_associations.json
@@ -29,8 +29,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -79,8 +79,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -129,8 +129,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -179,8 +179,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -229,8 +229,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -279,8 +279,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -318,8 +318,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -471,8 +471,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -518,8 +518,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -586,8 +586,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -654,8 +654,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -722,8 +722,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -761,8 +761,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -801,8 +801,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -844,8 +844,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -872,8 +872,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -900,8 +900,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -928,8 +928,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -956,8 +956,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -984,8 +984,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1012,8 +1012,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1040,8 +1040,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1068,8 +1068,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1096,8 +1096,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1124,8 +1124,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1152,8 +1152,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1180,8 +1180,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1208,8 +1208,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1236,8 +1236,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1264,8 +1264,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1292,8 +1292,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1320,8 +1320,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1348,8 +1348,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1376,8 +1376,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1404,8 +1404,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1432,8 +1432,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1460,8 +1460,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1488,8 +1488,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1516,8 +1516,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1544,8 +1544,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1572,8 +1572,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1600,8 +1600,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1628,8 +1628,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1656,8 +1656,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1684,8 +1684,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1712,8 +1712,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1740,8 +1740,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1768,8 +1768,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1796,8 +1796,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1824,8 +1824,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1852,8 +1852,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1880,8 +1880,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1908,8 +1908,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1936,8 +1936,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -1964,8 +1964,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2003,8 +2003,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2031,8 +2031,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2081,8 +2081,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2131,8 +2131,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2181,8 +2181,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2231,8 +2231,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2281,8 +2281,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2320,8 +2320,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2370,8 +2370,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2420,8 +2420,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2470,8 +2470,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2520,8 +2520,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2776,8 +2776,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2804,8 +2804,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2832,8 +2832,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2860,8 +2860,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2888,8 +2888,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2916,8 +2916,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2944,8 +2944,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -2972,8 +2972,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3000,8 +3000,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3028,8 +3028,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3056,8 +3056,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3106,8 +3106,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3156,8 +3156,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3206,8 +3206,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3256,8 +3256,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3306,8 +3306,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3356,8 +3356,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3406,8 +3406,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3456,8 +3456,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3506,8 +3506,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3556,8 +3556,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3606,8 +3606,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3656,8 +3656,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3706,8 +3706,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3756,8 +3756,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [
@@ -3806,8 +3806,8 @@
                 {
                     "types":
                     {
-                        "rType": "fault_inventory_object",
-                        "fType": "fault_led_group"
+                        "rType": "fault_identified_by",
+                        "fType": "fault_identifying"
                     },
                     "paths":
                     [

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-4u_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-4u_associations.json
@@ -40,8 +40,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -90,8 +90,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -140,8 +140,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -190,8 +190,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -240,8 +240,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -290,8 +290,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -329,8 +329,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -529,8 +529,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -597,8 +597,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -665,8 +665,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -733,8 +733,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -772,8 +772,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -812,8 +812,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -855,8 +855,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -883,8 +883,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -911,8 +911,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -939,8 +939,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -967,8 +967,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -995,8 +995,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1023,8 +1023,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1051,8 +1051,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1079,8 +1079,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1107,8 +1107,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1135,8 +1135,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1163,8 +1163,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1191,8 +1191,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1219,8 +1219,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1247,8 +1247,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1275,8 +1275,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1303,8 +1303,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1331,8 +1331,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1359,8 +1359,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1387,8 +1387,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1415,8 +1415,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1443,8 +1443,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1471,8 +1471,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1499,8 +1499,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1527,8 +1527,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1555,8 +1555,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1583,8 +1583,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1611,8 +1611,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1639,8 +1639,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1667,8 +1667,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1695,8 +1695,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1723,8 +1723,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1751,8 +1751,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1779,8 +1779,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1807,8 +1807,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1835,8 +1835,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1863,8 +1863,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1891,8 +1891,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1919,8 +1919,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1947,8 +1947,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -1975,8 +1975,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2014,8 +2014,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2042,8 +2042,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2092,8 +2092,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2142,8 +2142,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2192,8 +2192,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2242,8 +2242,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2292,8 +2292,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2331,8 +2331,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2381,8 +2381,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2431,8 +2431,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2481,8 +2481,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2531,8 +2531,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2787,8 +2787,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2815,8 +2815,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2843,8 +2843,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2871,8 +2871,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2899,8 +2899,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2927,8 +2927,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2955,8 +2955,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -2983,8 +2983,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3011,8 +3011,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3039,8 +3039,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3067,8 +3067,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3117,8 +3117,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3167,8 +3167,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3217,8 +3217,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3267,8 +3267,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3317,8 +3317,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3367,8 +3367,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3417,8 +3417,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3467,8 +3467,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3517,8 +3517,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3567,8 +3567,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3617,8 +3617,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3667,8 +3667,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3717,8 +3717,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3767,8 +3767,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3817,8 +3817,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3856,8 +3856,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3884,8 +3884,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3912,8 +3912,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3940,8 +3940,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3968,8 +3968,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -3996,8 +3996,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4024,8 +4024,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4052,8 +4052,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4080,8 +4080,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4108,8 +4108,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4136,8 +4136,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4164,8 +4164,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4192,8 +4192,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4220,8 +4220,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4248,8 +4248,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4276,8 +4276,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4304,8 +4304,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4332,8 +4332,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4360,8 +4360,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4388,8 +4388,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4416,8 +4416,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4444,8 +4444,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4472,8 +4472,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4500,8 +4500,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4528,8 +4528,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4556,8 +4556,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4584,8 +4584,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4612,8 +4612,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4640,8 +4640,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4668,8 +4668,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4696,8 +4696,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4724,8 +4724,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4752,8 +4752,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4780,8 +4780,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4808,8 +4808,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4836,8 +4836,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4864,8 +4864,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4892,8 +4892,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4920,8 +4920,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4948,8 +4948,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -4976,8 +4976,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5004,8 +5004,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5032,8 +5032,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5060,8 +5060,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5088,8 +5088,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5116,8 +5116,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5144,8 +5144,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5172,8 +5172,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5200,8 +5200,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5228,8 +5228,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5256,8 +5256,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5284,8 +5284,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5312,8 +5312,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5340,8 +5340,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5368,8 +5368,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5396,8 +5396,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5424,8 +5424,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5452,8 +5452,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5480,8 +5480,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5508,8 +5508,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5536,8 +5536,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5564,8 +5564,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [
@@ -5592,8 +5592,8 @@
                 {
                     "types":
                     {
-                        "rType": "identify_inventory_object",
-                        "fType": "identify_led_group"
+                        "rType": "identified_by",
+                        "fType": "identifying"
                     },
                     "paths":
                     [


### PR DESCRIPTION
Update the association configuration of `identify`[1] & `fault identify`[2] according to
the latest association interface.

[1] https://github.com/openbmc/phosphor-dbus-interfaces/commit/9eb460c6cfc2d7c2feb29c86f4beb31d4c3d9250
[2] https://github.com/openbmc/phosphor-dbus-interfaces/commit/e7c10bd5cdab6cd898e5cad0daab8c1128adc0c8

upstream:
https://gerrit.openbmc.org/c/openbmc/openbmc/+/61068
https://gerrit.openbmc.org/c/openbmc/openbmc/+/61069