### PR TITLE
meta-ibm: flash: Add Minimum Ship Level format

### DIFF
--- a/meta-ibm/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
+++ b/meta-ibm/recipes-phosphor/flash/phosphor-software-manager_%.bbappend
@@ -23,3 +23,6 @@ PACKAGECONFIG:append:p10bmc = " usb_code_update"
 # Enable Side Switch Boot
 PACKAGECONFIG:append:p10bmc = " side_switch_on_boot"
 
+# Set BMC Minimum Ship Level version format
+EXTRA_OEMESON:append:p10bmc = " -Dregex-bmc-msl='([a-z]+[0-9]{2})+([0-9]+).([0-9]+).([0-9]+)'"
+


### PR DESCRIPTION
Enable the minimum ship level format for p10bmc systems to match a string that starts with some characters such as "ibm", followed by 2 numbers for the processor version such as "10", followed by the tag number.

Change-Id: I4f3572db75b4fc1bb3c90c8c952d428d329b5d3a