### PR TITLE
meta-ibm: p10bmc: Add occ to processor associations

### DIFF
--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,bonnell_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,bonnell_associations.json
@@ -402,6 +402,17 @@
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
                ]
+            },
+            {
+                "types":
+                {
+                    "rType": "proc_instance",
+                    "fType": "occ_instance"
+                },
+                "paths":
+                [
+                    "/org/open_power/control/occ0"
+                ]
             }
          ]
       },
@@ -425,6 +436,17 @@
                "paths":[
                   "/xyz/openbmc_project/led/groups/enclosure_identify"
                ]
+            },
+            {
+                "types":
+                {
+                    "rType": "proc_instance",
+                    "fType": "occ_instance"
+                },
+                "paths":
+                [
+                    "/org/open_power/control/occ1"
+                ]
             }
          ]
       },

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,everest_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,everest_associations.json
@@ -2292,6 +2292,17 @@
                     [
                         "/xyz/openbmc_project/led/groups/cpu0_c14_identify"
                     ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ2"
+                    ]
                 }
             ]
         },
@@ -2319,6 +2330,17 @@
                     "paths":
                     [
                         "/xyz/openbmc_project/led/groups/cpu0_c14_identify"
+                    ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ3"
                     ]
                 }
             ]
@@ -2348,6 +2370,17 @@
                     [
                         "/xyz/openbmc_project/led/groups/cpu1_c19_identify"
                     ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ4"
+                    ]
                 }
             ]
         },
@@ -2375,6 +2408,17 @@
                     "paths":
                     [
                         "/xyz/openbmc_project/led/groups/cpu1_c19_identify"
+                    ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ5"
                     ]
                 }
             ]
@@ -2404,6 +2448,17 @@
                     [
                         "/xyz/openbmc_project/led/groups/cpu2_c56_identify"
                     ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ6"
+                    ]
                 }
             ]
         },
@@ -2431,6 +2486,17 @@
                     "paths":
                     [
                         "/xyz/openbmc_project/led/groups/cpu2_c56_identify"
+                    ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ7"
                     ]
                 }
             ]
@@ -2460,6 +2526,17 @@
                     [
                         "/xyz/openbmc_project/led/groups/cpu3_c61_identify"
                     ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ0"
+                    ]
                 }
             ]
         },
@@ -2487,6 +2564,17 @@
                     "paths":
                     [
                         "/xyz/openbmc_project/led/groups/cpu3_c61_identify"
+                    ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ1"
                     ]
                 }
             ]

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-2u_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-2u_associations.json
@@ -763,6 +763,17 @@
                     [
                         "/xyz/openbmc_project/led/groups/cpu0_identify"
                     ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ0"
+                    ]
                 }
             ]
         },
@@ -790,6 +801,17 @@
                     "paths":
                     [
                         "/xyz/openbmc_project/led/groups/cpu0_identify"
+                    ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ1"
                     ]
                 }
             ]
@@ -819,6 +841,17 @@
                     [
                         "/xyz/openbmc_project/led/groups/cpu1_identify"
                     ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ2"
+                    ]
                 }
             ]
         },
@@ -846,6 +879,17 @@
                     "paths":
                     [
                         "/xyz/openbmc_project/led/groups/cpu1_identify"
+                    ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ3"
                     ]
                 }
             ]
@@ -4736,33 +4780,33 @@
         },
         {
             "path": "cables/dp0_cable0",
-            "endpoints": 
+            "endpoints":
             [
                 {
-                    "types": 
+                    "types":
                     {
                         "rType": "attached_cables",
                         "fType": "upstream_resource"
                     },
-                    "paths": 
+                    "paths":
                     [
                         "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
                         "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10"
                     ]
                 },
                 {
-                    "types": 
+                    "types":
                     {
                         "rType": "attached_cables",
                         "fType": "downstream_resource"
                     },
-                    "paths": 
+                    "paths":
                     [
                         "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0"
                     ]
                 },
                 {
-                    "types": 
+                    "types":
                     {
                         "rType": "attached_cables",
                         "fType": "upstream_connector"
@@ -4788,27 +4832,27 @@
         },
         {
             "path": "cables/dp0_cable1",
-            "endpoints": 
+            "endpoints":
             [
                 {
-                    "types": 
+                    "types":
                     {
                         "rType": "attached_cables",
                         "fType": "upstream_resource"
                     },
-                    "paths": 
+                    "paths":
                     [
                         "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot8/pcie_card8",
                         "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10"
                     ]
                 },
                 {
-                    "types": 
+                    "types":
                     {
                         "rType": "attached_cables",
                         "fType": "downstream_resource"
                     },
-                    "paths": 
+                    "paths":
                     [
                         "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane0"
                     ]
@@ -4840,26 +4884,26 @@
         },
         {
             "path": "cables/dp1_cable0",
-            "endpoints": 
+            "endpoints":
             [
                 {
-                    "types": 
+                    "types":
                     {
                         "rType": "attached_cables",
                         "fType": "upstream_resource"
                     },
-                    "paths": 
+                    "paths":
                     [
                         "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11"
                     ]
                 },
                 {
-                    "types": 
+                    "types":
                     {
                         "rType": "attached_cables",
                         "fType": "downstream_resource"
                     },
-                    "paths": 
+                    "paths":
                     [
                         "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1"
                     ]
@@ -4890,26 +4934,26 @@
         },
         {
             "path": "cables/dp1_cable1",
-            "endpoints": 
+            "endpoints":
             [
                 {
-                    "types": 
+                    "types":
                     {
                         "rType": "attached_cables",
                         "fType": "upstream_resource"
                     },
-                    "paths": 
+                    "paths":
                     [
                         "/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot11/pcie_card11"
                     ]
                 },
                 {
-                    "types": 
+                    "types":
                     {
                         "rType": "attached_cables",
                         "fType": "downstream_resource"
                     },
-                    "paths": 
+                    "paths":
                     [
                         "/xyz/openbmc_project/inventory/system/chassis/motherboard/disk_backplane1"
                     ]

--- a/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-4u_associations.json
+++ b/meta-ibm/recipes-phosphor/inventory/phosphor-inventory-manager/p10bmc/ibm,rainier-4u_associations.json
@@ -918,6 +918,17 @@
                     [
                         "/xyz/openbmc_project/led/groups/cpu0_identify"
                     ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ0"
+                    ]
                 }
             ]
         },
@@ -945,6 +956,17 @@
                     "paths":
                     [
                         "/xyz/openbmc_project/led/groups/cpu0_identify"
+                    ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ1"
                     ]
                 }
             ]
@@ -974,6 +996,17 @@
                     [
                         "/xyz/openbmc_project/led/groups/cpu1_identify"
                     ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ2"
+                    ]
                 }
             ]
         },
@@ -1001,6 +1034,17 @@
                     "paths":
                     [
                         "/xyz/openbmc_project/led/groups/cpu1_identify"
+                    ]
+                },
+                {
+                    "types":
+                    {
+                        "rType": "proc_instance",
+                        "fType": "occ_instance"
+                    },
+                    "paths":
+                    [
+                        "/org/open_power/control/occ3"
                     ]
                 }
             ]


### PR DESCRIPTION
Adding an association between the OCCs and processors, so that the throttle status can be associated with the applicable processor.

Change-Id: I4f5b9f4ec347665316dae87e1995cebb52ef374c
Signed-off-by: Chris Cain <cjcain@us.ibm.com>