### PR TITLE
Fix bbappend file failed to load sensor yaml

### DIFF
--- a/meta-ibm/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-ibm/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -11,10 +11,7 @@ EXTRA_OEMESON:ibm-ac-server = " \
     "
 
 EXTRA_OEMESON:p10bmc = " \
+    -Dsensor-yaml-gen=${STAGING_DIR_HOST}${datadir}/p10bmc-yaml-config/ipmi-sensors.yaml \
+    -Dinvsensor-yaml-gen=${STAGING_DIR_HOST}${datadir}/p10bmc-yaml-config/ipmi-inventory-sensors.yaml \
     -Dfru-yaml-gen=${STAGING_DIR_HOST}${datadir}/p10bmc-yaml-config/ipmi-fru-read.yaml \
-    "
-EXTRA_OECONF:p10bmc = " \
-    SENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/p10bmc-yaml-config/ipmi-sensors.yaml \
-    INVSENSOR_YAML_GEN=${STAGING_DIR_HOST}${datadir}/p10bmc-yaml-config/ipmi-inventory-sensors.yaml \
-    FRU_YAML_GEN=${STAGING_DIR_HOST}${datadir}/p10bmc-yaml-config/ipmi-fru-read.yaml \
     "


### PR DESCRIPTION
Since phosphor-ipmi-host has been migrated to meson, the sensor yaml is incorrectly configured in the phosphor-ipmi-host_%.bbappend file in the 1050 branch, resulting in a failure to load, and the default configuration in the example is used.

Fixes https://github.com/ibm-openbmc/dev/issues/3625