### PR TITLE
Adding Phosphor Logging as a dependency for PLDM

### DIFF
--- a/meta-phosphor/recipes-phosphor/pldm/pldm_git.bb
+++ b/meta-phosphor/recipes-phosphor/pldm/pldm_git.bb
@@ -8,6 +8,7 @@ DEPENDS += "nlohmann-json"
 DEPENDS += "cli11"
 DEPENDS += "libpldm"
 DEPENDS += "libcereal"
+DEPENDS += "phosphor-logging"
 PV = "1.0+git${SRCPV}"
 PR = "r1"
 


### PR DESCRIPTION
This commit adds phosphor logging as a dependency for PLDM package in the PLDM recipe file.