### PR TITLE
Add TPMDisable interface

### DIFF
--- a/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-sensor-inventory-mrw-config/config.yaml
+++ b/meta-phosphor/recipes-phosphor/ipmi/phosphor-ipmi-sensor-inventory-mrw-config/config.yaml
@@ -182,6 +182,23 @@ tpm_required_sensor:
             type: "bool"
             assert: true
 
+disable_tpm_sensor:
+  path: /xyz/openbmc_project/control/host0/TPMDisable
+  serviceInterface: org.freedesktop.DBus.Properties
+  readingType: assertion
+  mutability: Mutability::Write|Mutability::Read
+  sensorNamePattern: nameLeaf
+  interfaces:
+    xyz.openbmc_project.Control.TPM.Policy:
+      TPMDisable:
+        Offsets:
+          0x00:
+            type: "bool"
+            assert: false
+          0x01:
+            type: "bool"
+            assert: true
+
 gpu_func_sensor:
   serviceInterface: xyz.openbmc_project.Inventory.Manager
   readingType: assertion

--- a/meta-phosphor/recipes-phosphor/settings/phosphor-settings-defaults/defaults.yaml
+++ b/meta-phosphor/recipes-phosphor/settings/phosphor-settings-defaults/defaults.yaml
@@ -104,6 +104,12 @@
           TPMEnable:
              Default: 'false'
 
+/xyz/openbmc_project/control/host0/TPMDisable:
+    - Interface: xyz.openbmc_project.Control.TPM.Policy
+      Properties:
+          TPMDisable:
+             Default: 'false'
+
 /xyz/openbmc_project/control/power_supply_attributes:
     - Interface: xyz.openbmc_project.Control.PowerSupplyAttributes
       Properties:


### PR DESCRIPTION
IBM has a new requirement to use a new sensor (disable_tpm_sensor) to disable TPM for P9.
This commit adds a sensor named `disable_tpm_sensor` to the ipmi sensor mrw configuration and set `true` by default.