### PR TITLE
Merge IPMI configuration to ibm-openbmc 1110-public branch

### DIFF
--- a/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config.bb
+++ b/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config.bb
@@ -7,6 +7,8 @@ inherit allarch
 
 SRC_URI = " \
     file://p10bmc-ipmi-fru.yaml \
+    file://p10bmc-ipmi-sensors.yaml \
+    file://p10bmc-ipmi-inventory-sensors.yaml \
     "
 
 S = "${WORKDIR}"
@@ -14,10 +16,16 @@ S = "${WORKDIR}"
 do_install() {
     install -m 0644 -D p10bmc-ipmi-fru.yaml \
         ${D}${datadir}/${BPN}/ipmi-fru-read.yaml
+    install -m 0644 -D p10bmc-ipmi-sensors.yaml \
+        ${D}${datadir}/${BPN}/ipmi-sensors.yaml
+    install -m 0644 -D p10bmc-ipmi-inventory-sensors.yaml \
+        ${D}${datadir}/${BPN}/ipmi-inventory-sensors.yaml
 }
 
 FILES:${PN}-dev = " \
     ${datadir}/${BPN}/ipmi-fru-read.yaml \
+    ${datadir}/${BPN}/ipmi-sensors.yaml \
+    ${datadir}/${BPN}/ipmi-inventory-sensors.yaml \
     "
 
 ALLOW_EMPTY:${PN} = "1"

--- a/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-fru.yaml
+++ b/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-fru.yaml
@@ -10,68 +10,6 @@
 #     d-bus Interfaces
 #       d-bus Properties
 #         IPMI Fru mapping
-0:
-  /system:
-    entityID: 23
-    entityInstance: 1
-    interfaces:
-      xyz.openbmc_project.Inventory.Item:
-        PrettyName:
-          IPMIFruProperty: Name
-          IPMIFruSection: Product
-      xyz.openbmc_project.Inventory.Decorator.Asset:
-        Manufacturer:
-          IPMIFruProperty: Manufacturer
-          IPMIFruSection: Product
-        PartNumber:
-          IPMIFruProperty: Part Number
-          IPMIFruSection: Product
-        SerialNumber:
-          IPMIFruProperty: Serial Number
-          IPMIFruSection: Product
-        BuildDate:
-          IPMIFruProperty: Mfg Date
-          IPMIFruSection: Product
-      xyz.openbmc_project.Inventory.Decorator.Revision:
-        Version:
-          IPMIFruProperty: Version
-          IPMIFruSection: Product
-      xyz.openbmc_project.Inventory.Item.System:
-  /system/chassis/motherboard/bmc:
-    entityID: 7
-    entityInstance: 1
-    interfaces:
-      xyz.openbmc_project.Inventory.Decorator.Asset:
-        BuildDate:
-          IPMIFruProperty: Mfg Date
-          IPMIFruSection: Board
-        Manufacturer:
-          IPMIFruProperty: Manufacturer
-          IPMIFruSection: Board
-        PartNumber:
-          IPMIFruProperty: Part Number
-          IPMIFruSection: Board
-        SerialNumber:
-          IPMIFruProperty: Serial Number
-          IPMIFruSection: Board
-      xyz.openbmc_project.Inventory.Item:
-        PrettyName:
-          IPMIFruProperty: Name
-          IPMIFruSection: Board
-  /system/chassis:
-    entityID: 7
-    entityInstance: 2
-    interfaces:
-      xyz.openbmc_project.Inventory.Decorator.Asset:
-        SerialNumber:
-          IPMIFruProperty: Serial Number
-          IPMIFruSection: Chassis
-        PartNumber:
-          IPMIFruProperty: Model Number
-          IPMIFruSection: Chassis
-        Model:
-          IPMIFruProperty: Type
-          IPMIFruSection: Chassis
 1:
   /system/chassis/motherboard/dimm0:
     entityID: 32
@@ -2154,4 +2092,87 @@
           IPMIFruProperty: Name
           IPMIFruSection: Product
       xyz.openbmc_project.Inventory.Item.PowerSupply:
-
+83:
+  /system:
+    entityID: 23
+    entityInstance: 1
+    interfaces:
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Product
+      xyz.openbmc_project.Inventory.Decorator.Asset:
+        Manufacturer:
+          IPMIFruProperty: Manufacturer
+          IPMIFruSection: Product
+        PartNumber:
+          IPMIFruProperty: Part Number
+          IPMIFruSection: Product
+        SerialNumber:
+          IPMIFruProperty: Serial Number
+          IPMIFruSection: Product
+        BuildDate:
+          IPMIFruProperty: Mfg Date
+          IPMIFruSection: Product
+      xyz.openbmc_project.Inventory.Decorator.Revision:
+        Version:
+          IPMIFruProperty: Version
+          IPMIFruSection: Product
+      xyz.openbmc_project.Inventory.Item.System:
+  /system/chassis:
+    entityID: 23
+    entityInstance: 2
+    interfaces:
+      xyz.openbmc_project.Inventory.Decorator.Asset:
+        SerialNumber:
+          IPMIFruProperty: Serial Number
+          IPMIFruSection: Chassis
+        PartNumber:
+          IPMIFruProperty: Model Number
+          IPMIFruSection: Chassis
+        Model:
+          IPMIFruProperty: Type
+          IPMIFruSection: Chassis
+  /system/chassis/motherboard:
+    entityID: 23
+    entityInstance: 3
+    interfaces:
+      xyz.openbmc_project.Inventory.Decorator.Asset:
+        BuildDate:
+          IPMIFruProperty: Mfg Date
+          IPMIFruSection: Board
+        Manufacturer:
+          IPMIFruProperty: Manufacturer
+          IPMIFruSection: Board
+        PartNumber:
+          IPMIFruProperty: Part Number
+          IPMIFruSection: Board
+        SerialNumber:
+          IPMIFruProperty: Serial Number
+          IPMIFruSection: Board
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Board
+84:
+  /system/chassis/motherboard/ebmc_card_bmc:
+    entityID: 7
+    entityInstance: 1
+    interfaces:
+      xyz.openbmc_project.Inventory.Decorator.Asset:
+        BuildDate:
+          IPMIFruProperty: Mfg Date
+          IPMIFruSection: Board
+        Manufacturer:
+          IPMIFruProperty: Manufacturer
+          IPMIFruSection: Board
+        PartNumber:
+          IPMIFruProperty: Part Number
+          IPMIFruSection: Board
+        SerialNumber:
+          IPMIFruProperty: Serial Number
+          IPMIFruSection: Board
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Board

--- a/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-fru.yaml
+++ b/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-fru.yaml
@@ -37,6 +37,41 @@
           IPMIFruProperty: Version
           IPMIFruSection: Product
       xyz.openbmc_project.Inventory.Item.System:
+  /system/chassis/motherboard/bmc:
+    entityID: 7
+    entityInstance: 1
+    interfaces:
+      xyz.openbmc_project.Inventory.Decorator.Asset:
+        BuildDate:
+          IPMIFruProperty: Mfg Date
+          IPMIFruSection: Board
+        Manufacturer:
+          IPMIFruProperty: Manufacturer
+          IPMIFruSection: Board
+        PartNumber:
+          IPMIFruProperty: Part Number
+          IPMIFruSection: Board
+        SerialNumber:
+          IPMIFruProperty: Serial Number
+          IPMIFruSection: Board
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Board
+  /system/chassis:
+    entityID: 7
+    entityInstance: 2
+    interfaces:
+      xyz.openbmc_project.Inventory.Decorator.Asset:
+        SerialNumber:
+          IPMIFruProperty: Serial Number
+          IPMIFruSection: Chassis
+        PartNumber:
+          IPMIFruProperty: Model Number
+          IPMIFruSection: Chassis
+        Model:
+          IPMIFruProperty: Type
+          IPMIFruSection: Chassis
 1:
   /system/chassis/motherboard/dimm0:
     entityID: 32
@@ -1949,3 +1984,174 @@
           IPMIFruProperty: Manufacturer
           IPMIFruSection: Board
       xyz.openbmc_project.Inventory.Item.Cpu:
+73:
+  /system/chassis/motherboard/fan0:
+    entityID: 29
+    entityInstance: 1
+    interfaces:
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Product
+74:
+  /system/chassis/motherboard/fan1:
+    entityID: 29
+    entityInstance: 2
+    interfaces:
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Product
+75:
+  /system/chassis/motherboard/fan2:
+    entityID: 29
+    entityInstance: 3
+    interfaces:
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Product
+76:
+  /system/chassis/motherboard/fan3:
+    entityID: 29
+    entityInstance: 4
+    interfaces:
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Product
+77:
+  /system/chassis/motherboard/fan4:
+    entityID: 29
+    entityInstance: 5
+    interfaces:
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Product
+78:
+  /system/chassis/motherboard/fan5:
+    entityID: 29
+    entityInstance: 6
+    interfaces:
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Product
+79:
+  /system/chassis/motherboard/powersupply0:
+    entityID: 19
+    entityInstance: 1
+    interfaces:
+      xyz.openbmc_project.Inventory.Decorator.Asset:
+        BuildDate:
+          IPMIFruProperty: Mfg Date
+          IPMIFruSection: Product
+        Manufacturer:
+          IPMIFruProperty: Manufacturer
+          IPMIFruSection: Product
+        Model:
+          IPMIFruProperty: Model Number
+          IPMIFruSection: Product
+        PartNumber:
+          IPMIFruProperty: Part Number
+          IPMIFruSection: Product
+        SerialNumber:
+          IPMIFruProperty: Serial Number
+          IPMIFruSection: Product
+      xyz.openbmc_project.Inventory.Decorator.Revision:
+        Version:
+          IPMIFruProperty: Version
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Product
+      xyz.openbmc_project.Inventory.Item.PowerSupply:
+80:
+  /system/chassis/motherboard/powersupply1:
+    entityID: 19
+    entityInstance: 2
+    interfaces:
+      xyz.openbmc_project.Inventory.Decorator.Asset:
+        BuildDate:
+          IPMIFruProperty: Mfg Date
+          IPMIFruSection: Product
+        Manufacturer:
+          IPMIFruProperty: Manufacturer
+          IPMIFruSection: Product
+        Model:
+          IPMIFruProperty: Model Number
+          IPMIFruSection: Product
+        PartNumber:
+          IPMIFruProperty: Part Number
+          IPMIFruSection: Product
+        SerialNumber:
+          IPMIFruProperty: Serial Number
+          IPMIFruSection: Product
+      xyz.openbmc_project.Inventory.Decorator.Revision:
+        Version:
+          IPMIFruProperty: Version
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Product
+      xyz.openbmc_project.Inventory.Item.PowerSupply:
+81:
+  /system/chassis/motherboard/powersupply2:
+    entityID: 19
+    entityInstance: 3
+    interfaces:
+      xyz.openbmc_project.Inventory.Decorator.Asset:
+        BuildDate:
+          IPMIFruProperty: Mfg Date
+          IPMIFruSection: Product
+        Manufacturer:
+          IPMIFruProperty: Manufacturer
+          IPMIFruSection: Product
+        Model:
+          IPMIFruProperty: Model Number
+          IPMIFruSection: Product
+        PartNumber:
+          IPMIFruProperty: Part Number
+          IPMIFruSection: Product
+        SerialNumber:
+          IPMIFruProperty: Serial Number
+          IPMIFruSection: Product
+      xyz.openbmc_project.Inventory.Decorator.Revision:
+        Version:
+          IPMIFruProperty: Version
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Product
+      xyz.openbmc_project.Inventory.Item.PowerSupply:
+82:
+  /system/chassis/motherboard/powersupply3:
+    entityID: 19
+    entityInstance: 4
+    interfaces:
+      xyz.openbmc_project.Inventory.Decorator.Asset:
+        BuildDate:
+          IPMIFruProperty: Mfg Date
+          IPMIFruSection: Product
+        Manufacturer:
+          IPMIFruProperty: Manufacturer
+          IPMIFruSection: Product
+        Model:
+          IPMIFruProperty: Model Number
+          IPMIFruSection: Product
+        PartNumber:
+          IPMIFruProperty: Part Number
+          IPMIFruSection: Product
+        SerialNumber:
+          IPMIFruProperty: Serial Number
+          IPMIFruSection: Product
+      xyz.openbmc_project.Inventory.Decorator.Revision:
+        Version:
+          IPMIFruProperty: Version
+      xyz.openbmc_project.Inventory.Item:
+        PrettyName:
+          IPMIFruProperty: Name
+          IPMIFruSection: Product
+      xyz.openbmc_project.Inventory.Item.PowerSupply:
+

--- a/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-inventory-sensors.yaml
+++ b/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-inventory-sensors.yaml
@@ -1,0 +1,370 @@
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm0:
+  sensorID: 0x01
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm1:
+  sensorID: 0x02
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm2:
+  sensorID: 0x03
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm3:
+  sensorID: 0x04
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm4:
+  sensorID: 0x05
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm5:
+  sensorID: 0x06
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm6:
+  sensorID: 0x07
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm7:
+  sensorID: 0x08
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm8:
+  sensorID: 0x09
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm9:
+  sensorID: 0x0A
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm10:
+  sensorID: 0x0B
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm11:
+  sensorID: 0x0C
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm12:
+  sensorID: 0x0D
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm13:
+  sensorID: 0x0E
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm14:
+  sensorID: 0x0F
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm15:
+  sensorID: 0x10
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm16:
+  sensorID: 0x11
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm17:
+  sensorID: 0x12
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm18:
+  sensorID: 0x13
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm19:
+  sensorID: 0x14
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm20:
+  sensorID: 0x15
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm21:
+  sensorID: 0x16
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm22:
+  sensorID: 0x17
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm23:
+  sensorID: 0x18
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm24:
+  sensorID: 0x19
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm25:
+  sensorID: 0x1A
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm26:
+  sensorID: 0x1B
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm27:
+  sensorID: 0x1C
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm28:
+  sensorID: 0x1D
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm29:
+  sensorID: 0x1E
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm30:
+  sensorID: 0x1F
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm31:
+  sensorID: 0x20
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm32:
+  sensorID: 0x21
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm33:
+  sensorID: 0x22
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm34:
+  sensorID: 0x23
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm35:
+  sensorID: 0x24
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm36:
+  sensorID: 0x25
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm37:
+  sensorID: 0x26
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm38:
+  sensorID: 0x27
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm39:
+  sensorID: 0x28
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm40:
+  sensorID: 0x29
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm41:
+  sensorID: 0x2A
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm42:
+  sensorID: 0x2B
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm43:
+  sensorID: 0x2C
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm44:
+  sensorID: 0x2D
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm45:
+  sensorID: 0x2E
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm46:
+  sensorID: 0x2F
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm47:
+  sensorID: 0x30
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm48:
+  sensorID: 0x31
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm49:
+  sensorID: 0x32
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm50:
+  sensorID: 0x33
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm51:
+  sensorID: 0x34
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm52:
+  sensorID: 0x35
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm53:
+  sensorID: 0x36
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm54:
+  sensorID: 0x37
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm55:
+  sensorID: 0x38
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm56:
+  sensorID: 0x39
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm57:
+  sensorID: 0x3A
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm58:
+  sensorID: 0x3B
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm59:
+  sensorID: 0x3C
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm60:
+  sensorID: 0x3D
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm61:
+  sensorID: 0x3E
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm62:
+  sensorID: 0x3F
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dimm63:
+  sensorID: 0x40
+  sensorType: 0x0C
+  eventReadingType: 0x6F
+  offset: 0x04
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu0:
+  sensorID: 0x41
+  sensorType: 0x07
+  eventReadingType: 0x6F
+  offset: 0x08
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1:
+  sensorID: 0x42
+  sensorType: 0x07
+  eventReadingType: 0x6F
+  offset: 0x08
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu0:
+  sensorID: 0x43
+  sensorType: 0x07
+  eventReadingType: 0x6F
+  offset: 0x08
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm1/cpu1:
+  sensorID: 0x44
+  sensorType: 0x07
+  eventReadingType: 0x6F
+  offset: 0x08
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm2/cpu0:
+  sensorID: 0x45
+  sensorType: 0x07
+  eventReadingType: 0x6F
+  offset: 0x08
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm2/cpu1:
+  sensorID: 0x46
+  sensorType: 0x07
+  eventReadingType: 0x6F
+  offset: 0x08
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm3/cpu0:
+  sensorID: 0x47
+  sensorType: 0x07
+  eventReadingType: 0x6F
+  offset: 0x08
+/xyz/openbmc_project/inventory/system/chassis/motherboard/dcm3/cpu1:
+  sensorID: 0x48
+  sensorType: 0x07
+  eventReadingType: 0x6F
+  offset: 0x08
+/xyz/openbmc_project/inventory/system/chassis/motherboard:
+  sensorID: 0x49
+  sensorType: 0xC7
+  eventReadingType: 0x03
+  offset: 0x00
+/xyz/openbmc_project/inventory/system:
+  sensorID: 0x4A
+  sensorType: 0x12
+  eventReadingType: 0x6F
+  offset: 0x02

--- a/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-sensors.yaml
+++ b/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-sensors.yaml
@@ -2158,3 +2158,55 @@
   sensorReadingType: 0x6F
   sensorType: 0x07
   serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x4B:
+  entityID: 0x22
+  entityInstance: 0x01
+  interfaces:
+    xyz.openbmc_project.State.Boot.Progress:
+      BootProgress:
+        Offsets:
+          0x00:
+            set: xyz.openbmc_project.State.Boot.Progress.ProgressStages.Unspecified
+            type: string
+          0x01:
+            set: xyz.openbmc_project.State.Boot.Progress.ProgressStages.MemoryInit
+            type: string
+          0x03:
+            set: xyz.openbmc_project.State.Boot.Progress.ProgressStages.SecondaryProcInit
+            type: string
+          0x07:
+            set: xyz.openbmc_project.State.Boot.Progress.ProgressStages.PCIInit
+            type: string
+          0x13:
+            set: xyz.openbmc_project.State.Boot.Progress.ProgressStages.OSStart
+            type: string
+          0x14:
+            set: xyz.openbmc_project.State.Boot.Progress.ProgressStages.MotherboardInit
+            type: string
+  mutability: Mutability::Write|Mutability::Read
+  path: /xyz/openbmc_project/state/host0
+  readingType: eventdata2
+  sensorNamePattern: nameProperty
+  sensorReadingType: 0x6F
+  sensorType: 0x0F
+  serviceInterface: org.freedesktop.DBus.Properties
+0x4C:
+  entityID: 0x23
+  entityInstance: 0x01
+  interfaces:
+    xyz.openbmc_project.Control.Boot.RebootPolicy:
+      AutoReboot:
+         Offsets:
+            0:
+              assert: false
+              type: bool
+            1:
+              assert: true
+              type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /xyz/openbmc_project/control/host0/auto_reboot
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0xC3
+  serviceInterface: org.freedesktop.DBus.Properties

--- a/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-sensors.yaml
+++ b/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-sensors.yaml
@@ -1928,7 +1928,6 @@
           0x07:
             assert: true
             deassert: false
-            skipOn: deassert
             type: bool
     xyz.openbmc_project.State.Decorator.OperationalStatus:
       Functional:
@@ -1958,7 +1957,6 @@
           0x07:
             assert: true
             deassert: false
-            skipOn: deassert
             type: bool
     xyz.openbmc_project.State.Decorator.OperationalStatus:
       Functional:
@@ -1988,7 +1986,6 @@
           0x07:
             assert: true
             deassert: false
-            skipOn: deassert
             type: bool
     xyz.openbmc_project.State.Decorator.OperationalStatus:
       Functional:
@@ -2018,7 +2015,6 @@
           0x07:
             assert: true
             deassert: false
-            skipOn: deassert
             type: bool
     xyz.openbmc_project.State.Decorator.OperationalStatus:
       Functional:
@@ -2048,7 +2044,6 @@
           0x07:
             assert: true
             deassert: false
-            skipOn: deassert
             type: bool
     xyz.openbmc_project.State.Decorator.OperationalStatus:
       Functional:
@@ -2078,7 +2073,6 @@
           0x07:
             assert: true
             deassert: false
-            skipOn: deassert
             type: bool
     xyz.openbmc_project.State.Decorator.OperationalStatus:
       Functional:
@@ -2108,7 +2102,6 @@
           0x07:
             assert: true
             deassert: false
-            skipOn: deassert
             type: bool
     xyz.openbmc_project.State.Decorator.OperationalStatus:
       Functional:
@@ -2138,7 +2131,6 @@
           0x07:
             assert: true
             deassert: false
-            skipOn: deassert
             type: bool
     xyz.openbmc_project.State.Decorator.OperationalStatus:
       Functional:

--- a/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-sensors.yaml
+++ b/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-sensors.yaml
@@ -1,0 +1,2160 @@
+0x01:
+  entityID: 0x20
+  entityInstance: 0x01
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm0
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x02:
+  entityID: 0x20
+  entityInstance: 0x02
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm1
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x03:
+  entityID: 0x20
+  entityInstance: 0x03
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm2
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x04:
+  entityID: 0x20
+  entityInstance: 0x04
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm3
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x05:
+  entityID: 0x20
+  entityInstance: 0x05
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm4
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x06:
+  entityID: 0x20
+  entityInstance: 0x06
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm5
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x07:
+  entityID: 0x20
+  entityInstance: 0x07
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm6
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x08:
+  entityID: 0x20
+  entityInstance: 0x08
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm7
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x09:
+  entityID: 0x20
+  entityInstance: 0x09
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm8
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x0A:
+  entityID: 0x20
+  entityInstance: 0x0A
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm9
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x0B:
+  entityID: 0x20
+  entityInstance: 0x0B
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm10
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x0C:
+  entityID: 0x20
+  entityInstance: 0x0C
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm11
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x0D:
+  entityID: 0x20
+  entityInstance: 0x0D
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm12
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x0E:
+  entityID: 0x20
+  entityInstance: 0x0E
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm13
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x0F:
+  entityID: 0x20
+  entityInstance: 0x0F
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm14
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x10:
+  entityID: 0x20
+  entityInstance: 0x10
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm15
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x11:
+  entityID: 0x20
+  entityInstance: 0x11
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm16
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x12:
+  entityID: 0x20
+  entityInstance: 0x12
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm17
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x13:
+  entityID: 0x20
+  entityInstance: 0x13
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm18
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x14:
+  entityID: 0x20
+  entityInstance: 0x14
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm19
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x15:
+  entityID: 0x20
+  entityInstance: 0x15
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm20
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x16:
+  entityID: 0x20
+  entityInstance: 0x16
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm21
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x17:
+  entityID: 0x20
+  entityInstance: 0x17
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm22
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x18:
+  entityID: 0x20
+  entityInstance: 0x18
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm23
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x19:
+  entityID: 0x20
+  entityInstance: 0x19
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm24
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x1A:
+  entityID: 0x20
+  entityInstance: 0x1A
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm25
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x1B:
+  entityID: 0x20
+  entityInstance: 0x1B
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm26
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x1C:
+  entityID: 0x20
+  entityInstance: 0x1C
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm27
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x1D:
+  entityID: 0x20
+  entityInstance: 0x1D
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm28
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x1E:
+  entityID: 0x20
+  entityInstance: 0x1E
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm29
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x1F:
+  entityID: 0x20
+  entityInstance: 0x1F
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm30
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x20:
+  entityID: 0x20
+  entityInstance: 0x20
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm31
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x21:
+  entityID: 0x20
+  entityInstance: 0x21
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm32
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x22:
+  entityID: 0x20
+  entityInstance: 0x22
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm33
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x23:
+  entityID: 0x20
+  entityInstance: 0x23
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm34
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x24:
+  entityID: 0x20
+  entityInstance: 0x24
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm35
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x25:
+  entityID: 0x20
+  entityInstance: 0x25
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm36
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x26:
+  entityID: 0x20
+  entityInstance: 0x26
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm37
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x27:
+  entityID: 0x20
+  entityInstance: 0x27
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm38
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x28:
+  entityID: 0x20
+  entityInstance: 0x28
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm39
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x29:
+  entityID: 0x20
+  entityInstance: 0x29
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm40
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x2A:
+  entityID: 0x20
+  entityInstance: 0x2A
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm41
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x2B:
+  entityID: 0x20
+  entityInstance: 0x2B
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm42
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x2C:
+  entityID: 0x20
+  entityInstance: 0x2C
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm43
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x2D:
+  entityID: 0x20
+  entityInstance: 0x2D
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm44
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x2E:
+  entityID: 0x20
+  entityInstance: 0x2E
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm45
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x2F:
+  entityID: 0x20
+  entityInstance: 0x2F
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm46
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x30:
+  entityID: 0x20
+  entityInstance: 0x30
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm47
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x31:
+  entityID: 0x20
+  entityInstance: 0x31
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm48
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x32:
+  entityID: 0x20
+  entityInstance: 0x32
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm49
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x33:
+  entityID: 0x20
+  entityInstance: 0x33
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm50
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x34:
+  entityID: 0x20
+  entityInstance: 0x34
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm51
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x35:
+  entityID: 0x20
+  entityInstance: 0x35
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm52
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x36:
+  entityID: 0x20
+  entityInstance: 0x36
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm53
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x37:
+  entityID: 0x20
+  entityInstance: 0x37
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm54
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x38:
+  entityID: 0x20
+  entityInstance: 0x38
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm55
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x39:
+  entityID: 0x20
+  entityInstance: 0x39
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm56
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x3A:
+  entityID: 0x20
+  entityInstance: 0x3A
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm57
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x3B:
+  entityID: 0x20
+  entityInstance: 0x3B
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm58
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x3C:
+  entityID: 0x20
+  entityInstance: 0x3C
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm59
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x3D:
+  entityID: 0x20
+  entityInstance: 0x3D
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm60
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x3E:
+  entityID: 0x20
+  entityInstance: 0x3E
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm61
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x3F:
+  entityID: 0x20
+  entityInstance: 0x3F
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm62
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x40:
+  entityID: 0x20
+  entityInstance: 0x40
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x06:
+            assert: true
+            deassert: false
+            type: bool
+        Prereqs:
+          0x04:
+            assert: false
+            deassert: true
+            type: bool
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dimm63
+  readingType: assertion
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x0C
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x41:
+  entityID: 0x03
+  entityInstance: 0x01
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x07:
+            assert: true
+            deassert: false
+            skipOn: deassert
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x08:
+            assert: false
+            deassert: true
+            type: bool
+        Prereqs:
+          0x07:
+            assert: true
+            deassert: false
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dcm0/cpu0
+  readingType: assertion
+  sensorNamePattern: nameParentLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x07
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x42:
+  entityID: 0x03
+  entityInstance: 0x02
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x07:
+            assert: true
+            deassert: false
+            skipOn: deassert
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x08:
+            assert: false
+            deassert: true
+            type: bool
+        Prereqs:
+          0x07:
+            assert: true
+            deassert: false
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dcm0/cpu1
+  readingType: assertion
+  sensorNamePattern: nameParentLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x07
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x43:
+  entityID: 0x03
+  entityInstance: 0x03
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x07:
+            assert: true
+            deassert: false
+            skipOn: deassert
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x08:
+            assert: false
+            deassert: true
+            type: bool
+        Prereqs:
+          0x07:
+            assert: true
+            deassert: false
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dcm1/cpu0
+  readingType: assertion
+  sensorNamePattern: nameParentLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x07
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x44:
+  entityID: 0x03
+  entityInstance: 0x04
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x07:
+            assert: true
+            deassert: false
+            skipOn: deassert
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x08:
+            assert: false
+            deassert: true
+            type: bool
+        Prereqs:
+          0x07:
+            assert: true
+            deassert: false
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dcm1/cpu1
+  readingType: assertion
+  sensorNamePattern: nameParentLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x07
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x45:
+  entityID: 0x03
+  entityInstance: 0x05
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x07:
+            assert: true
+            deassert: false
+            skipOn: deassert
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x08:
+            assert: false
+            deassert: true
+            type: bool
+        Prereqs:
+          0x07:
+            assert: true
+            deassert: false
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dcm2/cpu0
+  readingType: assertion
+  sensorNamePattern: nameParentLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x07
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x46:
+  entityID: 0x03
+  entityInstance: 0x06
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x07:
+            assert: true
+            deassert: false
+            skipOn: deassert
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x08:
+            assert: false
+            deassert: true
+            type: bool
+        Prereqs:
+          0x07:
+            assert: true
+            deassert: false
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dcm2/cpu1
+  readingType: assertion
+  sensorNamePattern: nameParentLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x07
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x47:
+  entityID: 0x03
+  entityInstance: 0x07
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x07:
+            assert: true
+            deassert: false
+            skipOn: deassert
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x08:
+            assert: false
+            deassert: true
+            type: bool
+        Prereqs:
+          0x07:
+            assert: true
+            deassert: false
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dcm3/cpu0
+  readingType: assertion
+  sensorNamePattern: nameParentLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x07
+  serviceInterface: xyz.openbmc_project.Inventory.Manager
+0x48:
+  entityID: 0x03
+  entityInstance: 0x08
+  interfaces:
+    xyz.openbmc_project.Inventory.Item:
+      Present:
+        Offsets:
+          0x07:
+            assert: true
+            deassert: false
+            skipOn: deassert
+            type: bool
+    xyz.openbmc_project.State.Decorator.OperationalStatus:
+      Functional:
+        Offsets:
+          0x08:
+            assert: false
+            deassert: true
+            type: bool
+        Prereqs:
+          0x07:
+            assert: true
+            deassert: false
+  mutability: Mutability::Write|Mutability::Read
+  path: /system/chassis/motherboard/dcm3/cpu1
+  readingType: assertion
+  sensorNamePattern: nameParentLeaf
+  sensorReadingType: 0x6F
+  sensorType: 0x07
+  serviceInterface: xyz.openbmc_project.Inventory.Manager

--- a/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-sensors.yaml
+++ b/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-sensors.yaml
@@ -2210,3 +2210,68 @@
   sensorReadingType: 0x6F
   sensorType: 0xC3
   serviceInterface: org.freedesktop.DBus.Properties
+0x4D: &FAN_RPM_DEFAULTS
+  bExp: 0x00
+  entityID: 0x27
+  entityInstance: 0x01
+  interfaces:
+    xyz.openbmc_project.Sensor.Value:
+      Value:
+        Offsets:
+          0xFF:
+            type: double
+  multiplierM: 0x64
+  offsetB: 0x00
+  path: /xyz/openbmc_project/sensors/fan_tach/fan0_0
+  rExp: 0x00
+  readingType: readingData
+  scale: 0x00
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x01
+  sensorType: 0x04
+  serviceInterface: org.freedesktop.DBus.Properties
+  unit: xyz.openbmc_project.Sensor.Value.Unit.RPMS
+0x4E:
+  <<: *FAN_RPM_DEFAULTS
+  entityInstance: 0x02
+  path: /xyz/openbmc_project/sensors/fan_tach/fan0_1
+0x4F:
+  <<: *FAN_RPM_DEFAULTS
+  entityInstance: 0x03
+  path: /xyz/openbmc_project/sensors/fan_tach/fan1_0
+0x50:
+  <<: *FAN_RPM_DEFAULTS
+  entityInstance: 0x04
+  path: /xyz/openbmc_project/sensors/fan_tach/fan1_1
+0x51:
+  <<: *FAN_RPM_DEFAULTS
+  entityInstance: 0x05
+  path: /xyz/openbmc_project/sensors/fan_tach/fan2_0
+0x52:
+  <<: *FAN_RPM_DEFAULTS
+  entityInstance: 0x06
+  path: /xyz/openbmc_project/sensors/fan_tach/fan2_1
+0x53:
+  <<: *FAN_RPM_DEFAULTS
+  entityInstance: 0x07
+  path: /xyz/openbmc_project/sensors/fan_tach/fan3_0
+0x54:
+  <<: *FAN_RPM_DEFAULTS
+  entityInstance: 0x08
+  path: /xyz/openbmc_project/sensors/fan_tach/fan3_1
+0x55:
+  <<: *FAN_RPM_DEFAULTS
+  entityInstance: 0x09
+  path: /xyz/openbmc_project/sensors/fan_tach/fan4_0
+0x56:
+  <<: *FAN_RPM_DEFAULTS
+  entityInstance: 0x0A
+  path: /xyz/openbmc_project/sensors/fan_tach/fan4_1
+0x57:
+  <<: *FAN_RPM_DEFAULTS
+  entityInstance: 0x0B
+  path: /xyz/openbmc_project/sensors/fan_tach/fan5_0
+0x58:
+  <<: *FAN_RPM_DEFAULTS
+  entityInstance: 0x0C
+  path: /xyz/openbmc_project/sensors/fan_tach/fan5_1

--- a/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-sensors.yaml
+++ b/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-sensors.yaml
@@ -2275,3 +2275,59 @@
   <<: *FAN_RPM_DEFAULTS
   entityInstance: 0x0C
   path: /xyz/openbmc_project/sensors/fan_tach/fan5_1
+0x59: &AMBIENT_TEMP_DEFAULTS
+  bExp: 0x00
+  entityID: 0x28
+  entityInstance: 0x01
+  interfaces:
+    xyz.openbmc_project.Sensor.Value:
+      Value:
+        Offsets:
+          0xFF:
+            type: double
+  multiplierM: 0x01
+  mutability: Mutability::Write|Mutability::Read
+  offsetB: 0x00
+  path: /xyz/openbmc_project/sensors/temperature/Ambient_0_Temp
+  rExp: 0x00
+  readingType: readingData
+  scale: 0x00
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x01
+  sensorType: 0x01
+  serviceInterface: org.freedesktop.DBus.Properties
+  unit: xyz.openbmc_project.Sensor.Value.Unit.DegreesC
+0x5A:
+  <<: *AMBIENT_TEMP_DEFAULTS
+  entityInstance: 0x02
+  path: /xyz/openbmc_project/sensors/temperature/Ambient_1_Temp
+0x5B:
+  <<: *AMBIENT_TEMP_DEFAULTS
+  entityInstance: 0x03
+  path: /xyz/openbmc_project/sensors/temperature/Ambient_2_Temp
+0x5C: &PCIE_TEMP_DEFAULTS
+  bExp: 0x00
+  entityID: 0x29
+  entityInstance: 0x01
+  interfaces:
+    xyz.openbmc_project.Sensor.Value:
+      Value:
+        Offsets:
+          0xFF:
+            type: double
+  multiplierM: 0x01
+  mutability: Mutability::Write|Mutability::Read
+  offsetB: 0x00
+  path: /xyz/openbmc_project/sensors/temperature/PCIE_0_Temp
+  rExp: 0x00
+  readingType: readingData
+  scale: 0x00
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x01
+  sensorType: 0x01
+  serviceInterface: org.freedesktop.DBus.Properties
+  unit: xyz.openbmc_project.Sensor.Value.Unit.DegreesC
+0x5D:
+  <<: *PCIE_TEMP_DEFAULTS
+  entityInstance: 0x02
+  path: /xyz/openbmc_project/sensors/temperature/PCIE_1_Temp

--- a/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-sensors.yaml
+++ b/meta-ibm/recipes-phosphor/configuration/p10bmc-yaml-config/p10bmc-ipmi-sensors.yaml
@@ -2331,3 +2331,359 @@
   <<: *PCIE_TEMP_DEFAULTS
   entityInstance: 0x02
   path: /xyz/openbmc_project/sensors/temperature/PCIE_1_Temp
+0x5E: &CPU_CORE_TEMP_DEFAULTS
+  bExp: 0x00
+  entityID: 0x2A
+  entityInstance: 0x01
+  interfaces:
+    xyz.openbmc_project.Sensor.Value:
+      Value:
+        Offsets:
+          0xFF:
+            type: double
+  multiplierM: 0x01
+  mutability: Mutability::Write|Mutability::Read
+  offsetB: 0x00
+  path: /xyz/openbmc_project/sensors/temperature/proc0_core0_0_temp
+  rExp: 0x00
+  readingType: readingData
+  scale: 0x00
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x01
+  sensorType: 0x01
+  serviceInterface: org.freedesktop.DBus.Properties
+  unit: xyz.openbmc_project.Sensor.Value.Unit.DegreesC
+0x5F:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x02
+  path: /xyz/openbmc_project/sensors/temperature/proc0_core0_1_temp
+0x60:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x03
+  path: /xyz/openbmc_project/sensors/temperature/proc1_core0_0_temp
+0x61:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x04
+  path: /xyz/openbmc_project/sensors/temperature/proc1_core0_1_temp
+0x62:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x05
+  path: /xyz/openbmc_project/sensors/temperature/proc2_core0_0_temp
+0x63:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x06
+  path: /xyz/openbmc_project/sensors/temperature/proc2_core0_1_temp
+0x64:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x07
+  path: /xyz/openbmc_project/sensors/temperature/proc3_core0_0_temp
+0x65:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x08
+  path: /xyz/openbmc_project/sensors/temperature/proc3_core0_1_temp
+0x66:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x09
+  path: /xyz/openbmc_project/sensors/temperature/proc4_core0_0_temp
+0x67:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x0A
+  path: /xyz/openbmc_project/sensors/temperature/proc4_core0_1_temp
+0x68:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x0B
+  path: /xyz/openbmc_project/sensors/temperature/proc5_core0_0_temp
+0x69:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x0C
+  path: /xyz/openbmc_project/sensors/temperature/proc5_core0_1_temp
+0x6A:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x0D
+  path: /xyz/openbmc_project/sensors/temperature/proc6_core0_0_temp
+0x6B:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x0E
+  path: /xyz/openbmc_project/sensors/temperature/proc6_core0_1_temp
+0x6C:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x0F
+  path: /xyz/openbmc_project/sensors/temperature/proc7_core0_0_temp
+0x6D:
+  <<: *CPU_CORE_TEMP_DEFAULTS
+  entityInstance: 0x10
+  path: /xyz/openbmc_project/sensors/temperature/proc7_core0_1_temp
+0x6E: &DIMM_TEMP_DEFAULTS
+  bExp: 0x00
+  entityID: 0x2B
+  entityInstance: 0x01
+  interfaces:
+    xyz.openbmc_project.Sensor.Value:
+      Value:
+        Offsets:
+          0xFF:
+            type: double
+  multiplierM: 0x01
+  mutability: Mutability::Write|Mutability::Read
+  offsetB: 0x00
+  path: /xyz/openbmc_project/sensors/temperature/dimm0_dram_temp
+  rExp: 0x00
+  readingType: readingData
+  scale: 0x00
+  sensorNamePattern: nameLeaf
+  sensorReadingType: 0x01
+  sensorType: 0x01
+  serviceInterface: org.freedesktop.DBus.Properties
+  unit: xyz.openbmc_project.Sensor.Value.Unit.DegreesC
+0x6F:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x02
+  path: /xyz/openbmc_project/sensors/temperature/dimm1_dram_temp
+0x70:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x03
+  path: /xyz/openbmc_project/sensors/temperature/dimm2_dram_temp
+0x71:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x04
+  path: /xyz/openbmc_project/sensors/temperature/dimm3_dram_temp
+0x72:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x05
+  path: /xyz/openbmc_project/sensors/temperature/dimm4_dram_temp
+0x73:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x06
+  path: /xyz/openbmc_project/sensors/temperature/dimm5_dram_temp
+0x74:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x07
+  path: /xyz/openbmc_project/sensors/temperature/dimm6_dram_temp
+0x75:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x08
+  path: /xyz/openbmc_project/sensors/temperature/dimm7_dram_temp
+0x76:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x09
+  path: /xyz/openbmc_project/sensors/temperature/dimm8_dram_temp
+0x77:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x0A
+  path: /xyz/openbmc_project/sensors/temperature/dimm9_dram_temp
+0x78:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x0B
+  path: /xyz/openbmc_project/sensors/temperature/dimm10_dram_temp
+0x79:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x0C
+  path: /xyz/openbmc_project/sensors/temperature/dimm11_dram_temp
+0x7A:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x0D
+  path: /xyz/openbmc_project/sensors/temperature/dimm12_dram_temp
+0x7B:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x0E
+  path: /xyz/openbmc_project/sensors/temperature/dimm13_dram_temp
+0x7C:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x0F
+  path: /xyz/openbmc_project/sensors/temperature/dimm14_dram_temp
+0x7D:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x10
+  path: /xyz/openbmc_project/sensors/temperature/dimm15_dram_temp
+0x7E:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x11
+  path: /xyz/openbmc_project/sensors/temperature/dimm16_dram_temp
+0x7F:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x12
+  path: /xyz/openbmc_project/sensors/temperature/dimm17_dram_temp
+0x80:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x13
+  path: /xyz/openbmc_project/sensors/temperature/dimm18_dram_temp
+0x81:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x14
+  path: /xyz/openbmc_project/sensors/temperature/dimm19_dram_temp
+0x82:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x15
+  path: /xyz/openbmc_project/sensors/temperature/dimm20_dram_temp
+0x83:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x16
+  path: /xyz/openbmc_project/sensors/temperature/dimm21_dram_temp
+0x84:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x17
+  path: /xyz/openbmc_project/sensors/temperature/dimm22_dram_temp
+0x85:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x18
+  path: /xyz/openbmc_project/sensors/temperature/dimm23_dram_temp
+0x86:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x19
+  path: /xyz/openbmc_project/sensors/temperature/dimm24_dram_temp
+0x87:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x1A
+  path: /xyz/openbmc_project/sensors/temperature/dimm25_dram_temp
+0x88:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x1B
+  path: /xyz/openbmc_project/sensors/temperature/dimm26_dram_temp
+0x89:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x1C
+  path: /xyz/openbmc_project/sensors/temperature/dimm27_dram_temp
+0x8A:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x1D
+  path: /xyz/openbmc_project/sensors/temperature/dimm28_dram_temp
+0x8B:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x1E
+  path: /xyz/openbmc_project/sensors/temperature/dimm29_dram_temp
+0x8C:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x1F
+  path: /xyz/openbmc_project/sensors/temperature/dimm30_dram_temp
+0x8D:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x20
+  path: /xyz/openbmc_project/sensors/temperature/dimm31_dram_temp
+0x8E:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x21
+  path: /xyz/openbmc_project/sensors/temperature/dimm32_dram_temp
+0x8F:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x22
+  path: /xyz/openbmc_project/sensors/temperature/dimm33_dram_temp
+0x90:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x23
+  path: /xyz/openbmc_project/sensors/temperature/dimm34_dram_temp
+0x91:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x24
+  path: /xyz/openbmc_project/sensors/temperature/dimm35_dram_temp
+0x92:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x25
+  path: /xyz/openbmc_project/sensors/temperature/dimm36_dram_temp
+0x93:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x26
+  path: /xyz/openbmc_project/sensors/temperature/dimm37_dram_temp
+0x94:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x27
+  path: /xyz/openbmc_project/sensors/temperature/dimm38_dram_temp
+0x95:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x28
+  path: /xyz/openbmc_project/sensors/temperature/dimm39_dram_temp
+0x96:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x29
+  path: /xyz/openbmc_project/sensors/temperature/dimm40_dram_temp
+0x97:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x2A
+  path: /xyz/openbmc_project/sensors/temperature/dimm41_dram_temp
+0x98:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x2B
+  path: /xyz/openbmc_project/sensors/temperature/dimm42_dram_temp
+0x99:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x2C
+  path: /xyz/openbmc_project/sensors/temperature/dimm43_dram_temp
+0x9A:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x2D
+  path: /xyz/openbmc_project/sensors/temperature/dimm44_dram_temp
+0x9B:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x2E
+  path: /xyz/openbmc_project/sensors/temperature/dimm45_dram_temp
+0x9C:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x2F
+  path: /xyz/openbmc_project/sensors/temperature/dimm46_dram_temp
+0x9D:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x30
+  path: /xyz/openbmc_project/sensors/temperature/dimm47_dram_temp
+0x9E:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x31
+  path: /xyz/openbmc_project/sensors/temperature/dimm48_dram_temp
+0x9F:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x32
+  path: /xyz/openbmc_project/sensors/temperature/dimm49_dram_temp
+0xA0:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x33
+  path: /xyz/openbmc_project/sensors/temperature/dimm50_dram_temp
+0xA1:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x34
+  path: /xyz/openbmc_project/sensors/temperature/dimm51_dram_temp
+0xA2:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x35
+  path: /xyz/openbmc_project/sensors/temperature/dimm52_dram_temp
+0xA3:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x36
+  path: /xyz/openbmc_project/sensors/temperature/dimm53_dram_temp
+0xA4:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x37
+  path: /xyz/openbmc_project/sensors/temperature/dimm54_dram_temp
+0xA5:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x38
+  path: /xyz/openbmc_project/sensors/temperature/dimm55_dram_temp
+0xA6:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x39
+  path: /xyz/openbmc_project/sensors/temperature/dimm56_dram_temp
+0xA7:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x3A
+  path: /xyz/openbmc_project/sensors/temperature/dimm57_dram_temp
+0xA8:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x3B
+  path: /xyz/openbmc_project/sensors/temperature/dimm58_dram_temp
+0xA9:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x3C
+  path: /xyz/openbmc_project/sensors/temperature/dimm59_dram_temp
+0xAA:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x3D
+  path: /xyz/openbmc_project/sensors/temperature/dimm60_dram_temp
+0xAB:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x3E
+  path: /xyz/openbmc_project/sensors/temperature/dimm61_dram_temp
+0xAC:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x3F
+  path: /xyz/openbmc_project/sensors/temperature/dimm62_dram_temp
+0xAD:
+  <<: *DIMM_TEMP_DEFAULTS
+  entityInstance: 0x40
+  path: /xyz/openbmc_project/sensors/temperature/dimm63_dram_temp

--- a/meta-ibm/recipes-phosphor/ipmi/phosphor-ipmi-config/p10bmc/dcmi_sensors.json
+++ b/meta-ibm/recipes-phosphor/ipmi/phosphor-ipmi-config/p10bmc/dcmi_sensors.json
@@ -1,0 +1,113 @@
+{
+    "inlet": [
+        {
+            "instance": 1,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/Ambient_0_Temp",
+            "record_id": 89
+        },
+        {
+            "instance": 2,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/Ambient_1_Temp",
+            "record_id": 90
+        },
+        {
+            "instance": 3,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/Ambient_2_Temp",
+            "record_id": 91
+        }
+    ],
+    "baseboard": [
+        {
+            "instance": 1,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/PCIE_0_Temp",
+            "record_id": 92
+        },
+        {
+            "instance": 2,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/PCIE_1_Temp",
+            "record_id": 93
+        }
+    ],
+    "cpu": [
+        {
+            "instance": 1,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc0_core0_0_temp",
+            "record_id": 94
+        },
+        {
+            "instance": 2,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc0_core0_1_temp",
+            "record_id": 95
+        },
+        {
+            "instance": 3,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc1_core0_0_temp",
+            "record_id": 96
+        },
+        {
+            "instance": 4,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc1_core0_1_temp",
+            "record_id": 97
+        },
+        {
+            "instance": 5,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc2_core0_0_temp",
+            "record_id": 98
+        },
+        {
+            "instance": 6,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc2_core0_1_temp",
+            "record_id": 99
+        },
+        {
+            "instance": 7,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc3_core0_0_temp",
+            "record_id": 100
+        },
+        {
+            "instance": 8,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc3_core0_1_temp",
+            "record_id": 101
+        },
+        {
+            "instance": 9,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc4_core0_0_temp",
+            "record_id": 102
+        },
+        {
+            "instance": 10,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc4_core0_1_temp",
+            "record_id": 103
+        },
+        {
+            "instance": 11,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc5_core0_0_temp",
+            "record_id": 104
+        },
+        {
+            "instance": 12,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc5_core0_1_temp",
+            "record_id": 105
+        },
+        {
+            "instance": 13,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc6_core0_0_temp",
+            "record_id": 106
+        },
+        {
+            "instance": 14,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc6_core0_1_temp",
+            "record_id": 107
+        },
+        {
+            "instance": 15,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc7_core0_0_temp",
+            "record_id": 108
+        },
+        {
+            "instance": 16,
+            "dbus": "/xyz/openbmc_project/sensors/temperature/proc7_core0_1_temp",
+            "record_id": 109
+        }
+    ]
+}

--- a/meta-ibm/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
+++ b/meta-ibm/recipes-phosphor/ipmi/phosphor-ipmi-host_%.bbappend
@@ -11,5 +11,7 @@ EXTRA_OEMESON:ibm-ac-server = " \
     "
 
 EXTRA_OEMESON:p10bmc = " \
+    -Dsensor-yaml-gen=${STAGING_DIR_HOST}${datadir}/p10bmc-yaml-config/ipmi-sensors.yaml \
+    -Dinvsensor-yaml-gen=${STAGING_DIR_HOST}${datadir}/p10bmc-yaml-config/ipmi-inventory-sensors.yaml \
     -Dfru-yaml-gen=${STAGING_DIR_HOST}${datadir}/p10bmc-yaml-config/ipmi-fru-read.yaml \
     "


### PR DESCRIPTION
Merge the following patch into the ibm-openbmc 1110-public branch:

- 6644db6bf7960f0525f7ad9354e0681055e76920: meta-ibm:p10bmc: Add dcmi sensors
- 79d18b3f1a43a8d851b14e0a9555309657bab377: meta-ibm:p10bmc: Print sdr and sensor info
- 4ad1adbc3b9b34a0ce0dff133a6962f06b59d309: meta-ibm:p10bmc Add more sensors
- 482f8b009c2b8e3ad31e6ac8abddfe98f7c4965f: meta-ibm:p10bmc: Display fans sensor information
- 01846631913c40c5c93cdb3ef2f338054a1078ae: p10bmc:meta-ibm: Add Ambient and PCIe sensors
- 655ce20ede184f11b2db7125804bb0ac736c6710: Add CPU and DIMM temperatures
- 2813b044fa0f953baaa65f865f0841c0bd54adf5: meta-ibm:p10bmc: Enable setting cpu Present property
- fe7040f0546084e6734f96d5ae532d24bc7b2a5c: **Merged upstream**
- 8b088d05c0df247a1b4aa96f632464254a4a2ac4: meta-ibm:p10bmc: Print fans/power supply FRU info
- 36ffa61f8bf474b3be54affea7487e0ff69e49b4: meta-ibm:p10bmc Print system and bmc FRU info